### PR TITLE
chore(histogram): update @data-ui/histogram for better bins

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-histogram/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-histogram/package.json
@@ -26,8 +26,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@data-ui/histogram": "^0.0.64",
-    "@data-ui/theme": "^0.0.62",
+    "@data-ui/histogram": "^0.0.77",
+    "@data-ui/theme": "^0.0.77",
     "@vx/legend": "^0.0.170",
     "@vx/responsive": "0.0.172",
     "@vx/scale": "^0.0.165",

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-histogram/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-histogram/Stories.jsx
@@ -12,7 +12,7 @@ export default [
           formData: {
             colorScheme: 'd3Category10',
             globalOpacity: 1,
-            linkLength: 25,
+            linkLength: 15, // binCount
             normalized: false,
             xAxisLabel: 'Score',
             yAxisLabel: 'Count',


### PR DESCRIPTION
🏆 Enhancements

This bumps `@data-ui/histogram` to `^0.0.77` to improve the binning logic for raw numeric data. See [relevant PR in `@data-ui`](https://github.com/williaster/data-ui/pull/172) for more details. 

The relevant thing to focus on below is that the last bin (`1 - 1.05`) in the _before_ image only contains values `<=1`, and so in the _after_ it has been combined with the last bin (`0.95 - 1`). tl;dr the last bin is now end-inclusive instead of making a new bin (which is less intuitive, though it's technically "correct")

**Storybook before**
<img src="https://user-images.githubusercontent.com/4496521/54306743-4ca08300-4587-11e9-8aa1-207782ff9677.png" width="400" />

**After**
<img src="https://user-images.githubusercontent.com/4496521/54306941-bf116300-4587-11e9-8f92-2d6049b5a25c.png" width="400" />

@conglei @kristw 