### PR TITLE
fix: nvd3 line chart y axis bounds

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -301,7 +301,7 @@ function nvd3Vis(element, props) {
         }
         chart.xScale(d3.time.scale.utc());
         chart.interpolate(lineInterpolation);
-        chart.clipEdge(true);
+        chart.clipEdge(false);
         break;
 
       case 'time_pivot':
@@ -586,6 +586,7 @@ function nvd3Vis(element, props) {
       const yMax = isDefined(max) ? max : trueMax;
       if (yMin !== trueMin || yMax !== trueMax) {
         chart.yDomain([yMin, yMax]);
+        chart.clipEdge(true);
       }
     }
 

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -24,6 +24,7 @@ import nv from 'nvd3';
 import mathjs from 'mathjs';
 import moment from 'moment';
 import PropTypes from 'prop-types';
+import { isDefined } from '@superset-ui/core';
 import { t } from '@superset-ui/translation';
 import { CategoricalColorNamespace } from '@superset-ui/color';
 import { getNumberFormatter, NumberFormats } from '@superset-ui/number-format';
@@ -59,7 +60,6 @@ import {
   stringOrObjectWithLabelType,
 } from './PropTypes';
 import './NVD3Vis.css';
-import { isDefined } from '@superset-ui/core';
 
 const { getColor, getScale } = CategoricalColorNamespace;
 

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -59,6 +59,7 @@ import {
   stringOrObjectWithLabelType,
 } from './PropTypes';
 import './NVD3Vis.css';
+import { isDefined } from '@superset-ui/core';
 
 const { getColor, getScale } = CategoricalColorNamespace;
 
@@ -300,7 +301,7 @@ function nvd3Vis(element, props) {
         }
         chart.xScale(d3.time.scale.utc());
         chart.interpolate(lineInterpolation);
-        chart.clipEdge(false);
+        chart.clipEdge(true);
         break;
 
       case 'time_pivot':
@@ -470,9 +471,6 @@ function nvd3Vis(element, props) {
       }
     }
 
-    if (chart.forceY && yAxisBounds && (yAxisBounds[0] !== null || yAxisBounds[1] !== null)) {
-      chart.forceY(yAxisBounds);
-    }
     if (yIsLogScale) {
       chart.yScale(d3.scale.log());
     }
@@ -579,6 +577,16 @@ function nvd3Vis(element, props) {
       // shift labels to the left so they look better
       const xTicks = svg.select('.nv-x.nv-axis > g').selectAll('g');
       xTicks.selectAll('text').attr('dx', -6.5);
+    }
+
+    if (chart.yDomain && Array.isArray(yAxisBounds) && yAxisBounds.length === 2) {
+      const [min, max] = yAxisBounds;
+      const [trueMin, trueMax] = chart.yAxis.scale().domain();
+      const yMin = isDefined(min) ? min : trueMin;
+      const yMax = isDefined(max) ? max : trueMax;
+      if (yMin !== trueMin || yMax !== trueMax) {
+        chart.yDomain([yMin, yMax]);
+      }
     }
 
     // align yAxis1 and yAxis2 ticks

--- a/packages/superset-ui-plugins-demo/package.json
+++ b/packages/superset-ui-plugins-demo/package.json
@@ -37,6 +37,7 @@
     "@storybook/react": "^4.1.11",
     "@superset-ui/chart": "^0.10.2",
     "@superset-ui/color": "^0.10.1",
+    "@superset-ui/time-format": "^0.10.1",
     "@superset-ui/translation": "^0.10.0",
     "babel-loader": "^8.0.4",
     "bootstrap": "^3.3.6",

--- a/packages/superset-ui-plugins-demo/storybook-config/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/storybook-config/webpack.config.js
@@ -23,7 +23,9 @@ module.exports = (storybookBaseConfig, configType, defaultConfig) => {
 
   defaultConfig.module.rules.push({
     exclude: /node_modules/,
-    include: new RegExp(`${path.resolve(__dirname, '../../superset-ui-(plugin|preset)-')}.+/src`),
+    include: new RegExp(
+      `${path.resolve(__dirname, '../../superset-ui-(legacy-)*(plugin|preset)-')}.+/src`,
+    ),
     test: /\.jsx?$/,
     use: defaultConfig.module.rules[0].use,
   });

--- a/packages/superset-ui-plugins-demo/storybook/stories/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/index.js
@@ -6,6 +6,7 @@ import sequentialCommon from '@superset-ui/color/esm/colorSchemes/sequential/com
 import sequentialD3 from '@superset-ui/color/esm/colorSchemes/sequential/d3';
 import { configure } from '@superset-ui/translation';
 import { getCategoricalSchemeRegistry, getSequentialSchemeRegistry } from '@superset-ui/color';
+import { getTimeFormatterRegistry, smartDateFormatter } from '@superset-ui/time-format';
 
 setAddon(JSXAddon);
 
@@ -26,6 +27,10 @@ const sequentialSchemeRegistry = getSequentialSchemeRegistry();
     sequentialSchemeRegistry.registerValue(scheme.id, scheme);
   });
 });
+
+getTimeFormatterRegistry()
+  .registerValue('smart_date', smartDateFormatter)
+  .setDefaultKey('smart_date');
 
 const EMPTY_EXAMPLES = [
   {

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/Stories.jsx
@@ -74,4 +74,39 @@ export default [
     storyName: 'Markers',
     storyPath: 'legacy-|preset-chart-nvd3|LineChartPlugin',
   },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="line"
+        chartProps={{
+          datasource: { verboseMap: {} },
+          formData: {
+            bottomMargin: 'auto',
+            colorScheme: 'd3Category10',
+            leftMargin: 'auto',
+            lineInterpolation: 'linear',
+            richTooltip: true,
+            showBrush: 'auto',
+            showLegend: true,
+            showMarkers: false,
+            vizType: 'line',
+            xAxisFormat: 'smart_date',
+            xAxisLabel: '',
+            xAxisShowminmax: false,
+            xTicksLayout: 'auto',
+            yAxisBounds: [0, 60000],
+            yAxisFormat: '.3s',
+            yAxisLabel: '',
+            yAxisShowminmax: false,
+            yLogScale: false,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'yAxisBounds',
+    storyPath: 'legacy-|preset-chart-nvd3|LineChartPlugin',
+  },
 ];

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/Stories.jsx
@@ -74,39 +74,4 @@ export default [
     storyName: 'Markers',
     storyPath: 'legacy-|preset-chart-nvd3|LineChartPlugin',
   },
-  {
-    renderStory: () => (
-      <SuperChart
-        chartType="line"
-        chartProps={{
-          datasource: { verboseMap: {} },
-          formData: {
-            bottomMargin: 'auto',
-            colorScheme: 'd3Category10',
-            leftMargin: 'auto',
-            lineInterpolation: 'linear',
-            richTooltip: true,
-            showBrush: 'auto',
-            showLegend: true,
-            showMarkers: false,
-            vizType: 'line',
-            xAxisFormat: 'smart_date',
-            xAxisLabel: '',
-            xAxisShowminmax: false,
-            xTicksLayout: 'auto',
-            yAxisBounds: [0, 60000],
-            yAxisFormat: '.3s',
-            yAxisLabel: '',
-            yAxisShowminmax: false,
-            yLogScale: false,
-          },
-          height: 400,
-          payload: { data },
-          width: 400,
-        }}
-      />
-    ),
-    storyName: 'yAxisBounds',
-    storyPath: 'legacy-|preset-chart-nvd3|LineChartPlugin',
-  },
 ];

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/YAxisStories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/YAxisStories.jsx
@@ -1,0 +1,64 @@
+/* eslint-disable no-magic-numbers */
+import React from 'react';
+import { SuperChart } from '@superset-ui/chart';
+import data from './data';
+
+export default [
+  {
+    renderStory: () => (
+      <div className="container">
+        <h2>yAxisBounds</h2>
+        <pre>yAxisBounds=[0, 60000]</pre>
+        <SuperChart
+          chartType="line"
+          chartProps={{
+            datasource: { verboseMap: {} },
+            formData: {
+              richTooltip: true,
+              showLegend: false,
+              vizType: 'line',
+              yAxisBounds: [0, 60000],
+            },
+            height: 200,
+            payload: { data },
+            width: 400,
+          }}
+        />
+        <pre>yAxisBounds=[null, 60000]</pre>
+        <SuperChart
+          chartType="line"
+          chartProps={{
+            datasource: { verboseMap: {} },
+            formData: {
+              richTooltip: true,
+              showLegend: false,
+              vizType: 'line',
+              yAxisBounds: [null, 60000],
+            },
+            height: 200,
+            payload: { data },
+            width: 400,
+          }}
+        />
+        <pre>yAxisBounds=[40000, null]</pre>
+        <SuperChart
+          chartType="line"
+          chartProps={{
+            datasource: { verboseMap: {} },
+            formData: {
+              richTooltip: true,
+              showLegend: false,
+              vizType: 'line',
+              yAxisBounds: [40000, null],
+            },
+            height: 200,
+            payload: { data },
+            width: 400,
+          }}
+        />
+      </div>
+    ),
+    storyName: 'yAxisBounds',
+    storyPath: 'legacy-|preset-chart-nvd3|LineChartPlugin',
+  },
+];

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
@@ -1,4 +1,4 @@
-import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3/src';
+import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3';
 import Stories from './Stories';
 import YAxisStories from './YAxisStories';
 

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
@@ -1,8 +1,9 @@
 import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3/src';
 import Stories from './Stories';
+import YAxisStories from './YAxisStories';
 
 new LineChartPlugin().configure({ key: 'line' }).register();
 
 export default {
-  examples: [...Stories],
+  examples: [...Stories, ...YAxisStories],
 };

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
@@ -1,4 +1,4 @@
-import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3';
+import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3/src';
 import Stories from './Stories';
 
 new LineChartPlugin().configure({ key: 'line' }).register();


### PR DESCRIPTION
🐛 Bug Fix

* Previously the bound will not be applied if the extent of data is larger than the specified bound.
* Address Airbnb's PRODUCT-70657

🏠 Internal

* Add examples in storybook to demonstrate different settings for `yAxisBounds`
* Set default time format for storybook. 

![image](https://user-images.githubusercontent.com/1659771/54320233-7cf91900-45a9-11e9-96c4-61b7037b401a.png)

@michellethomas @williaster @conglei @graceguo-supercat