### PR TITLE
fix: dual line chart color consistency for secondary y axis

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -33,6 +33,7 @@ export function cleanColorInput(value) {
   // for superset series that should have the same color
   return String(value)
     .trim()
+    .replace(' (right axis)', '')
     .split(', ')
     .filter(k => !TIME_SHIFT_PATTERN.test(k))
     .join(', ');

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/DualLine/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/DualLine/Stories.jsx
@@ -3,6 +3,11 @@ import React from 'react';
 import { SuperChart } from '@superset-ui/chart';
 import data from './data';
 
+const reverseData = data.map(series => ({
+  ...series,
+  yAxis: series.yAxis === 1 ? 2 : 1,
+}));
+
 export default [
   {
     renderStory: () => (
@@ -12,8 +17,6 @@ export default [
           datasource: { verboseMap: {} },
           formData: {
             colorScheme: 'd3Category10',
-            metric: 'avg__num',
-            metric2: 'sum__num',
             vizType: 'dual_line',
             xAxisFormat: 'smart_date',
             yAxis2Format: '.3s',
@@ -26,6 +29,46 @@ export default [
       />
     ),
     storyName: 'Basic',
+    storyPath: 'legacy-|preset-chart-nvd3|DualLineChartPlugin',
+  },
+  {
+    renderStory: () => (
+      <div>
+        <SuperChart
+          chartType="dual-line"
+          chartProps={{
+            datasource: { verboseMap: {} },
+            formData: {
+              colorScheme: 'd3Category10',
+              vizType: 'dual_line',
+              xAxisFormat: 'smart_date',
+              yAxis2Format: '.3s',
+              yAxisFormat: '.3s',
+            },
+            height: 400,
+            payload: { data },
+            width: 400,
+          }}
+        />
+        <SuperChart
+          chartType="dual-line"
+          chartProps={{
+            datasource: { verboseMap: {} },
+            formData: {
+              colorScheme: 'd3Category10',
+              vizType: 'dual_line',
+              xAxisFormat: 'smart_date',
+              yAxis2Format: '.3s',
+              yAxisFormat: '.3s',
+            },
+            height: 400,
+            payload: { data: reverseData },
+            width: 400,
+          }}
+        />
+      </div>
+    ),
+    storyName: 'Swap y-axis with consistent color',
     storyPath: 'legacy-|preset-chart-nvd3|DualLineChartPlugin',
   },
 ];


### PR DESCRIPTION
🐛 Bug Fix

* Address Airbnb's PRODUCT-67932

> It appears that if a metric appears in the "metric_2" parameter of a dual-axis chart, it will not have the same color as a metric of the same name which is set in the "metric" parameter of a different chart, and visa versa. Practically, this means that the same metric will be colored inconsistently in a dashboard.

## Solution

This was due to `nvd3` appending `' (right axis)'` to category name before passing to color function. 

### Before 

![image](https://user-images.githubusercontent.com/1659771/54322032-c862f580-45b0-11e9-9459-6ddd68d66b17.png)

### After

![image](https://user-images.githubusercontent.com/1659771/54322023-ba14d980-45b0-11e9-81ff-c515af559adb.png)

cc: @michellethomas @graceguo-supercat 