### PR TITLE
fix: show only necessary tick labels on log scale

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -573,6 +573,11 @@ function nvd3Vis(element, props) {
       .attr('width', width)
       .call(chart);
 
+    // For log scale, only show 1, 10, 100, 1000, ...
+    if (yIsLogScale) {
+      chart.yAxis.tickFormat(d => (Math.log10(d) % 1 === 0 ? yAxisFormatter(d) : ''));
+    }
+
     if (xLabelRotation > 0) {
       // shift labels to the left so they look better
       const xTicks = svg.select('.nv-x.nv-axis > g').selectAll('g');

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/LogStories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/LogStories.jsx
@@ -1,0 +1,29 @@
+/* eslint-disable no-magic-numbers */
+import React from 'react';
+import { SuperChart } from '@superset-ui/chart';
+import data from './data';
+
+export default [
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="line"
+        chartProps={{
+          datasource: { verboseMap: {} },
+          formData: {
+            richTooltip: true,
+            vizType: 'line',
+            yAxisBounds: [1, 60000],
+            yAxisFormat: ',d',
+            yLogScale: true,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'Log scale',
+    storyPath: 'legacy-|preset-chart-nvd3|LineChartPlugin',
+  },
+];

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
@@ -1,4 +1,4 @@
-import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3/src';
+import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3';
 import Stories from './Stories';
 import YAxisStories from './YAxisStories';
 import LogStories from './LogStories';

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/index.js
@@ -1,9 +1,10 @@
-import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3';
+import { LineChartPlugin } from '../../../../../superset-ui-legacy-preset-chart-nvd3/src';
 import Stories from './Stories';
 import YAxisStories from './YAxisStories';
+import LogStories from './LogStories';
 
 new LineChartPlugin().configure({ key: 'line' }).register();
 
 export default {
-  examples: [...Stories, ...YAxisStories],
+  examples: [...Stories, ...YAxisStories, ...LogStories],
 };


### PR DESCRIPTION
🐛 Bug Fix

* For log scale, only show labels for 1, 10, 100, 1000, ... 
* Address Airbnb's PRODUCT-65125

### Before

![image](https://user-images.githubusercontent.com/1659771/54324506-39a7a600-45bb-11e9-9686-64f56e8de706.png)

### After

![image](https://user-images.githubusercontent.com/1659771/54324517-462bfe80-45bb-11e9-964e-1d165f1defaf.png)

@michellethomas @graceguo-supercat 