### PR TITLE
 fix: y axis bounds when input are nan

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -48,6 +48,7 @@ import {
   setAxisShowMaxMin,
   stringifyTimeRange,
   wrapTooltip,
+  computeYDomain,
 } from './utils';
 import {
   annotationLayerType,
@@ -593,15 +594,23 @@ function nvd3Vis(element, props) {
       xTicks.selectAll('text').attr('dx', -6.5);
     }
 
+    // Apply y-axis bounds
     if (chart.yDomain && Array.isArray(yAxisBounds) && yAxisBounds.length === 2) {
       const [min, max] = yAxisBounds;
-      const [trueMin, trueMax] = chart.yAxis.scale().domain();
-      const yMin = isDefined(min) ? min : trueMin;
-      const yMax = isDefined(max) ? max : trueMax;
-      if (yMin !== trueMin || yMax !== trueMax) {
-        chart.yDomain([yMin, yMax]);
-        chart.clipEdge(true);
+      const hasCustomMin = isDefined(min) && !Number.isNaN(min);
+      const hasCustomMax = isDefined(max) && !Number.isNaN(max);
+      let yMin;
+      let yMax;
+      if (hasCustomMin && hasCustomMax) {
+        yMin = min;
+        yMax = max;
+      } else {
+        const [trueMin, trueMax] = computeYDomain(data);
+        yMin = hasCustomMin ? min : trueMin;
+        yMax = hasCustomMax ? max : trueMax;
       }
+      chart.yDomain([yMin, yMax]);
+      chart.clipEdge(true);
     }
 
     // align yAxis1 and yAxis2 ticks

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -584,7 +584,7 @@ function nvd3Vis(element, props) {
 
     // For log scale, only show 1, 10, 100, 1000, ...
     if (yIsLogScale) {
-      chart.yAxis.tickFormat(d => (Math.log10(d) % 1 === 0 ? yAxisFormatter(d) : ''));
+      chart.yAxis.tickFormat(d => (d !== 0 && Math.log10(d) % 1 === 0 ? yAxisFormatter(d) : ''));
     }
 
     if (xLabelRotation > 0) {

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -300,3 +300,15 @@ export function setAxisShowMaxMin(axis, showminmax) {
     axis.showMaxMin(showminmax);
   }
 }
+
+export function computeYDomain(data) {
+  if (Array.isArray(data) && data.length > 0 && Array.isArray(data[0].values)) {
+    const extents = data.map(row => d3.extent(row.values, v => v.y));
+    const minOfMin = d3.min(extents, ([min]) => min);
+    const maxOfMax = d3.max(extents, ([, max]) => max);
+
+    return [minOfMin, maxOfMax];
+  }
+
+  return [0, 1];
+}

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/YAxisStories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Line/YAxisStories.jsx
@@ -8,6 +8,21 @@ export default [
     renderStory: () => (
       <div className="container">
         <h2>yAxisBounds</h2>
+        <pre>yAxisBounds=undefined</pre>
+        <SuperChart
+          chartType="line"
+          chartProps={{
+            datasource: { verboseMap: {} },
+            formData: {
+              richTooltip: true,
+              showLegend: false,
+              vizType: 'line',
+            },
+            height: 200,
+            payload: { data },
+            width: 400,
+          }}
+        />
         <pre>yAxisBounds=[0, 60000]</pre>
         <SuperChart
           chartType="line"


### PR DESCRIPTION
🐛 Bug Fix

A few follow-ups after integrating back into `incubator-superset`

* fix: y axis bounds when input are nan. The Superset explore controls sometimes pass `[NaN, NaN]` as bound values and it breaks the chart. 
* fix: avoid log scale computation for 0
