### PR TITLE
fix: make pivot table handle null string

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-pivot-table/src/PivotTable.js
+++ b/packages/superset-ui-legacy-plugin-chart-pivot-table/src/PivotTable.js
@@ -71,7 +71,7 @@ function PivotTable(element, props) {
         const metric = cols[i];
         const format = columnFormats[metric] || numberFormat || '.3s';
         const tdText = $(this)[0].textContent;
-        if (!Number.isNaN(tdText) && tdText !== '') {
+        if (!Number.isNaN(tdText) && tdText !== '' && tdText.trim().toLowerCase() !== 'null') {
           $(this)[0].textContent = formatNumber(format, tdText);
           $(this).attr('data-sort', tdText);
         }

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-pivot-table/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-pivot-table/Stories.jsx
@@ -34,4 +34,34 @@ export default [
     storyName: 'Basic',
     storyPath: 'legacy-|plugin-chart-pivot-table|PivotTableChartPlugin',
   },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="pivot-table"
+        chartProps={{
+          datasource: {
+            columnFormats: {},
+            verboseMap: {
+              sum__num: 'sum__num',
+            },
+          },
+          formData: {
+            groupby: ['name'],
+            numberFormat: '.3s',
+          },
+          height: 400,
+          payload: {
+            data: {
+              columns: [['sum__num', 'other'], ['sum__num', 'All']],
+              html:
+                '<table border="1" class="dataframe dataframe table table-striped table-bordered table-condensed table-hover">\n  <thead>\n    <tr>\n      <th></th>\n      <th colspan="2" halign="left">sum__num</th>\n    </tr>\n    <tr>\n      <th>state</th>\n      <th>other</th>\n      <th>All</th>\n    </tr>\n    <tr>\n      <th>name</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>Christopher</th>\n      <td>null</td>\n      <td>803607</td>\n    </tr>\n    <tr>\n      <th>David</th>\n      <td>null</td>\n      <td>673992</td>\n    </tr>\n    <tr>\n      <th>James</th>\n      <td>749686</td>\n      <td>null</td>\n    </tr>\n    <tr>\n      <th>Jennifer</th>\n      <td>587540</td>\n      <td>null</td>\n    </tr>\n    <tr>\n      <th>John</th>\n      <td>638450</td>\n      <td>638450</td>\n    </tr>\n    <tr>\n      <th>Joshua</th>\n      <td>null</td>\n      <td>548044</td>\n    </tr>\n    <tr>\n      <th>Matthew</th>\n      <td>608212</td>\n      <td>608212</td>\n    </tr>\n    <tr>\n      <th>Michael</th>\n      <td>1047996</td>\n      <td>1047996</td>\n    </tr>\n    <tr>\n      <th>Robert</th>\n      <td>575592</td>\n      <td>575592</td>\n    </tr>\n    <tr>\n      <th>William</th>\n      <td>574464</td>\n      <td>574464</td>\n    </tr>\n    <tr>\n      <th>All</th>\n      <td>6807583</td>\n      <td>6807583</td>\n    </tr>\n  </tbody>\n</table>',
+            },
+          },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'With null',
+    storyPath: 'legacy-|plugin-chart-pivot-table|PivotTableChartPlugin',
+  },
 ];


### PR DESCRIPTION
🐛 Bug Fix

* make pivot table handle `'null'` string and do not try to format it as `NaN`

### Before

![image](https://user-images.githubusercontent.com/1659771/54647258-0b184800-4a5f-11e9-9964-e1752fe0af0e.png)

### After

![image](https://user-images.githubusercontent.com/1659771/54647276-19fefa80-4a5f-11e9-9ea4-4f16c73ed509.png)

related to: https://github.com/apache/incubator-superset/pull/4905
cc: @john-bodley 