### PR TITLE
fix: line chart tooltip should use full datetime format

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -548,7 +548,7 @@ function nvd3Vis(element, props) {
       chart.useInteractiveGuideline(true);
       if (vizType === 'line') {
         chart.interactiveLayer.tooltip.contentGenerator(d =>
-          generateRichLineTooltipContent(d, xAxisFormatter, yAxisFormatter),
+          generateRichLineTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
         );
       }
     }


### PR DESCRIPTION
Currently, the line chart tooltip is using the `xAxisFormatter` which truncate the date part if the corresponding date and time contains hour, minute and second.  We should use `smartDateVerboseFormatter` instead.