### PR TITLE
style: improve the tooltip for the time pivot chart

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -40,6 +40,7 @@ import {
   generateBubbleTooltipContent,
   generateMultiLineTooltipContent,
   generateRichLineTooltipContent,
+  generateTimePivotTooltip,
   getMaxLabelSize,
   getTimeOrNumberFormatter,
   hideTooltips,
@@ -539,6 +540,11 @@ function nvd3Vis(element, props) {
           return `rgba(${r}, ${g}, ${b}, ${alpha})`;
         });
       }
+
+      chart.useInteractiveGuideline(true);
+      chart.interactiveLayer.tooltip.contentGenerator(d =>
+        generateTimePivotTooltip(d, xAxisFormatter, yAxisFormatter),
+      );
     } else if (vizType !== 'bullet') {
       const colorFn = getScale(colorScheme);
       chart.color(d => d.color || colorFn(cleanColorInput(d[colorKey])));

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -160,6 +160,35 @@ export function generateMultiLineTooltipContent(d, xFormatter, yFormatters) {
   return tooltip;
 }
 
+export function generateTimePivotTooltip(d, xFormatter, yFormatter) {
+  const tooltipTitle = xFormatter(d.value);
+  let tooltip = '';
+
+  tooltip +=
+    "<table><thead><tr><td colspan='3'>" +
+    `<strong class='x-value'>${tooltipTitle}</strong>` +
+    '</td></tr></thead><tbody>';
+
+  d.series.forEach((series, i) => {
+    if (series.highlight) {
+      let label = '';
+      if (series.key === 'current') {
+        label = series.key;
+      } else {
+        label = `${series.key} of the selected frequence`;
+      }
+      tooltip +=
+        "<tr><td class='legend-color-guide'>" +
+        `<div style="background-color: ${series.color};"></div></td>` +
+        `<td class='key'>${label}</td>` +
+        `<td class='value'>${yFormatter(series.value)}</td></tr>`;
+    }
+  });
+
+  tooltip += '</tbody></table>';
+  return dompurify.sanitize(tooltip);
+}
+
 function getLabel(stringOrObjectWithLabel) {
   return stringOrObjectWithLabel.label || stringOrObjectWithLabel;
 }

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -169,7 +169,7 @@ export function generateTimePivotTooltip(d, xFormatter, yFormatter) {
     `<strong class='x-value'>${tooltipTitle}</strong>` +
     '</td></tr></thead><tbody>';
 
-  d.series.forEach((series, i) => {
+  d.series.forEach(series => {
     if (series.highlight) {
       let label = '';
       if (series.key === 'current') {
@@ -186,6 +186,7 @@ export function generateTimePivotTooltip(d, xFormatter, yFormatter) {
   });
 
   tooltip += '</tbody></table>';
+
   return dompurify.sanitize(tooltip);
 }
 


### PR DESCRIPTION
🏆 Enhancements

This PR improves the tooltip for the Time Pivot Chart.

This is how it looks like before.
![image](https://user-images.githubusercontent.com/17309187/55173081-4dfdae00-5138-11e9-8be0-c8691e4d5dd9.png)

This is how it looks like after the improvement.
![image](https://user-images.githubusercontent.com/17309187/55173123-5d7cf700-5138-11e9-8ac0-2dfe95191ff5.png)
