### PR TITLE
chore: add eslint react fragment rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "license": "Apache-2.0",
   "devDependencies": {
-    "@superset-ui/build-config": "^0.0.4",
+    "@superset-ui/build-config": "^0.0.6",
     "@superset-ui/chart": "^0.10.8",
     "@superset-ui/color": "^0.10.0",
     "@superset-ui/connection": "^0.10.0",

--- a/packages/superset-ui-preset-chart-xy/package.json
+++ b/packages/superset-ui-preset-chart-xy/package.json
@@ -53,6 +53,6 @@
     "@superset-ui/number-format": "^0.10.0",
     "@superset-ui/time-format": "^0.10.0",
     "@superset-ui/translation": "^0.10.0",
-    "react": "^15 || ^16"
+    "react": "^15 || ^16.2"
   }
 }

--- a/packages/superset-ui-preset-chart-xy/package.json
+++ b/packages/superset-ui-preset-chart-xy/package.json
@@ -53,6 +53,6 @@
     "@superset-ui/number-format": "^0.10.0",
     "@superset-ui/time-format": "^0.10.0",
     "@superset-ui/translation": "^0.10.0",
-    "react": "^15 || ^16.2"
+    "react": "^16.2"
   }
 }

--- a/packages/superset-ui-preset-chart-xy/src/Line/createTooltip.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/Line/createTooltip.tsx
@@ -20,7 +20,7 @@ export default function createTooltip(encoder: Encoder, allSeries: Series[]) {
   }) {
     return (
       <TooltipFrame>
-        <React.Fragment>
+        <>
           <div>
             <strong>{encoder.channels.x.formatValue(datum.x)}</strong>
           </div>
@@ -41,7 +41,7 @@ export default function createTooltip(encoder: Encoder, allSeries: Series[]) {
                 }))}
             />
           )}
-        </React.Fragment>
+        </>
       </TooltipFrame>
     );
   }

--- a/packages/superset-ui-preset-chart-xy/src/components/ChartLegend.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/components/ChartLegend.tsx
@@ -86,6 +86,6 @@ export default class ChartLegend<
       );
     });
 
-    return <React.Fragment>{legends}</React.Fragment>;
+    return <>{legends}</>;
   }
 }


### PR DESCRIPTION
🏠 Internal

* Enforce using `<>` instead of `<React.Fragment>`
https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-fragments.md

* `Fragment` is only available after `react` `16.2` so update the requirement for packages that use `Fragment` as well. 

* Close #29 