### PR TITLE
fix: big number with trendline fix

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-big-number/src/BigNumber/BigNumber.jsx
+++ b/packages/superset-ui-legacy-preset-chart-big-number/src/BigNumber/BigNumber.jsx
@@ -229,8 +229,10 @@ class BigNumberVis extends React.PureComponent {
       return (
         <div className={className}>
           <div className="text-container" style={{ height: allTextHeight }}>
-            {this.renderHeader(Math.ceil(headerFontSize * height))}
-            {this.renderSubheader(Math.ceil(subheaderFontSize * height))}
+            {this.renderHeader(Math.ceil(headerFontSize * (1 - PROPORTION.TRENDLINE) * height))}
+            {this.renderSubheader(
+              Math.ceil(subheaderFontSize * (1 - PROPORTION.TRENDLINE) * height),
+            )}
           </div>
           {this.renderTrendline(chartHeight)}
         </div>


### PR DESCRIPTION
🐛 Bug Fix

Most of the time the big number looks fine in vizs with trendlines but upon further testing, there are some wonky cases. I have adjusted the sizing if the trendline is displayed.