### PR TITLE
fix(legacy-preset-chart-nvd3): stacked bar charts labels

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -49,7 +49,7 @@ export function getTimeOrNumberFormatter(format) {
 
 export function drawBarValues(svg, data, stacked, axisFormat) {
   const format = getNumberFormatter(axisFormat);
-  const countSeriesDisplayed = data.length;
+  const countSeriesDisplayed = data.filter(d => !d.disabled).length;
 
   const totalStackedValues =
     stacked && data.length !== 0

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Bar/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Bar/Stories.jsx
@@ -126,4 +126,44 @@ export default [
     storyName: 'Bar with positive and negative values',
     storyPath: 'legacy-|preset-chart-nvd3|BarChartPlugin',
   },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="bar"
+        chartProps={{
+          datasource: {
+            verboseMap: {},
+          },
+          formData: {
+            bottomMargin: 'auto',
+            colorCcheme: 'd3Category10',
+            contribution: false,
+            groupby: ['region'],
+            lineInterpolation: 'linear',
+            metrics: ['sum__SP_POP_TOTL'],
+            richTooltip: true,
+            showBarValue: true,
+            showBrush: 'auto',
+            showControls: false,
+            showLegend: true,
+            stackedStyle: 'stack',
+            barStacked: true,
+            vizType: 'bar',
+            xAxisFormat: '%Y',
+            xAxisLabel: '',
+            xAxisShowminmax: false,
+            xTicksLayout: 'auto',
+            yAxisBounds: [null, null],
+            yAxisFormat: '.3s',
+            yLogScale: false,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'Stacked bar with values',
+    storyPath: 'legacy-|preset-chart-nvd3|BarChartPlugin',
+  },
 ];

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Bar/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Bar/Stories.jsx
@@ -135,6 +135,7 @@ export default [
             verboseMap: {},
           },
           formData: {
+            barStacked: true,
             bottomMargin: 'auto',
             colorCcheme: 'd3Category10',
             contribution: false,
@@ -147,7 +148,6 @@ export default [
             showControls: false,
             showLegend: true,
             stackedStyle: 'stack',
-            barStacked: true,
             vizType: 'bar',
             xAxisFormat: '%Y',
             xAxisLabel: '',


### PR DESCRIPTION
🐛 Bug Fix

Labels are not being displayed on stacked bar charts with some of the groups disabled in the legend, because the number of series being displayed is being computed incorrectly. I fixed it by ignoring disabled series, and added a new story to test it.