### PR TITLE
fix: remove sticky tooltip when query returns no data in explore view

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/ReactNVD3.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/ReactNVD3.js
@@ -18,5 +18,10 @@
  */
 import { reactify } from '@superset-ui/chart';
 import Component from './NVD3Vis';
+import { hideTooltips } from './utils';
 
-export default reactify(Component);
+function willUnmount() {
+  hideTooltips(true);
+}
+
+export default reactify(Component, { willUnmount });


### PR DESCRIPTION
🐛 Bug Fix

Tap into the newly added `willUnmount` hook in https://github.com/apache-superset/superset-ui/pull/131 to clean up sticky tooltip that nvd3 adds to `body` directly. This removes such tooltips that were left behind in the explore view with the new query returns 'no data'.
![image](https://user-images.githubusercontent.com/1521435/55679822-ee856800-58c6-11e9-90a6-056e519a4d40.png)
