### PR TITLE
fix: y-axis bounds for stacked viz types

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -613,7 +613,7 @@ function nvd3Vis(element, props) {
       } else {
         let [trueMin, trueMax] = [0, 1];
         // These viz types can be stacked
-        if (isVizTypes(['area', 'bar'])) {
+        if (isVizTypes(['area', 'bar', 'dist_bar'])) {
           [trueMin, trueMax] = chart.yAxis.scale().domain();
         } else {
           [trueMin, trueMax] = computeYDomain(data);

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -611,7 +611,13 @@ function nvd3Vis(element, props) {
         yMin = min;
         yMax = max;
       } else {
-        const [trueMin, trueMax] = computeYDomain(data);
+        let [trueMin, trueMax] = [0, 1];
+        // These viz types can be stacked
+        if (isVizTypes(['area', 'bar'])) {
+          [trueMin, trueMax] = chart.yAxis.scale().domain();
+        } else {
+          [trueMin, trueMax] = computeYDomain(data);
+        }
         yMin = hasCustomMin ? min : trueMin;
         yMax = hasCustomMax ? max : trueMax;
       }


### PR DESCRIPTION
🐛 Bug Fix

The y-axis bounds are cut off for stacked viz types because we do not take into account stacked data values when calculating the min and max. 

Before:
<img width="1421" alt="Screen Shot 2019-04-08 at 2 43 36 PM" src="https://user-images.githubusercontent.com/47833996/55758894-efc0ad00-5a0c-11e9-8711-1c7f33ac11bf.png">

<img width="1419" alt="Screen Shot 2019-04-08 at 2 43 22 PM" src="https://user-images.githubusercontent.com/47833996/55758899-f18a7080-5a0c-11e9-8b5f-e61bd25511c7.png">

After:

<img width="1420" alt="Screen Shot 2019-04-08 at 2 44 13 PM" src="https://user-images.githubusercontent.com/47833996/55758908-f6e7bb00-5a0c-11e9-9b47-271bf1ad187d.png">

<img width="1422" alt="Screen Shot 2019-04-08 at 2 44 22 PM" src="https://user-images.githubusercontent.com/47833996/55758914-fa7b4200-5a0c-11e9-83ea-260f6f0a4a0f.png">
