### PR TITLE
fix: use correct number format

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-big-number/src/BigNumber/transformProps.js
+++ b/packages/superset-ui-legacy-preset-chart-big-number/src/BigNumber/transformProps.js
@@ -63,7 +63,7 @@ export default function transformProps(chartProps) {
         const compareValue = sortedData[compareIndex][metricName];
         percentChange =
           compareValue === 0 ? 0 : (bigNumber - compareValue) / Math.abs(compareValue);
-        const formatPercentChange = getNumberFormatter(NumberFormats.PERCENT_CHANGE_1_POINT);
+        const formatPercentChange = getNumberFormatter(NumberFormats.PERCENT_SIGNED_1_POINT);
         formattedSubheader = `${formatPercentChange(percentChange)} ${compareSuffix}`;
       }
     }


### PR DESCRIPTION
🐛 Bug Fix

This was referring to an old variable name. Updated to use the correct variable name.
