### PR TITLE
fix: list css as side effects

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-calendar/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-calendar/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-calendar",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Calendar Heatmap",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-chord/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-chord/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-chord",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Chord Diagram",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-country-map/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-country-map/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-country-map",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Country Map",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-event-flow/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-event-flow/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-event-flow",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Event Flow",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-force-directed/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-force-directed/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-force-directed",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Force-directed Graph",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-heatmap/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-heatmap/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-heatmap",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Heatmap",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-histogram/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-histogram/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-histogram",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Histogram",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-horizon/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-horizon/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-horizon",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Horizon",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-iframe/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-iframe/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-iframe",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Iframe",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-map-box/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-map-box/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-map-box",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - MapBox",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-markup/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-markup/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-markup",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Markup",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-paired-t-test/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-paired-t-test/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-paired-t-test",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Paired T Test",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-parallel-coordinates/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-parallel-coordinates/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-parallel-coordinates",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Parallel Coordinates",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-partition/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-partition/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-partition",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Partition",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-pivot-table/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-pivot-table/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-pivot-table",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Pivot Table",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-rose/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-rose/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-rose",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Nightingale Rose Diagram",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-sankey/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-sankey/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-sankey",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Sankey Diagram",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-sunburst",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Sunburst",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-table/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-table/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-table",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Table",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-treemap/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-treemap/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-treemap",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Treemap",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-word-cloud/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-word-cloud/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-word-cloud",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - Word Cloud",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-plugin-chart-world-map/package.json
+++ b/packages/superset-ui-legacy-plugin-chart-world-map/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-plugin-chart-world-map",
   "version": "0.10.5",
   "description": "Superset Legacy Chart - World Map",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-preset-chart-big-number/package.json
+++ b/packages/superset-ui-legacy-preset-chart-big-number/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-preset-chart-big-number",
   "version": "0.10.10",
   "description": "Superset Legacy Chart - Big Number",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-legacy-preset-chart-nvd3/package.json
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/legacy-preset-chart-nvd3",
   "version": "0.10.9",
   "description": "Superset Legacy Chart - NVD3",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-plugin-chart-word-cloud/package.json
+++ b/packages/superset-ui-plugin-chart-word-cloud/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/plugin-chart-word-cloud",
   "version": "0.10.5",
   "description": "Superset Chart Plugin - Word Cloud",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [

--- a/packages/superset-ui-preset-chart-xy/package.json
+++ b/packages/superset-ui-preset-chart-xy/package.json
@@ -2,7 +2,8 @@
   "name": "@superset-ui/preset-chart-xy",
   "version": "0.10.5",
   "description": "Superset Chart - XY",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
+
   "main": "lib/index.js",
   "module": "esm/index.js",
   "files": [


### PR DESCRIPTION
🐛 Bug Fix

**Problem**
related to apache/incubator-superset#7058

The root cause ends up being the `sideEffects: true` that is set in each `package.json`. `webpack` in `production` mode uses this to determine if the package has any side effects and when it is declared `false`, it (via treeshaking) drops the file that does not export anything, including `css`. Treeshaking only applies to `esm` so when importing `lib` it works fine. 

**Solution**
Setting `sideEffects: ["*.css"]` seems to solve the problem. 
This is an alternative solution to #55 and subset of #56.

**Reference**
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free