### PR TITLE
feat: make line chart query operate in time series mode

### DIFF
--- a/packages/superset-ui-preset-chart-xy/src/Line/buildQuery.ts
+++ b/packages/superset-ui-preset-chart-xy/src/Line/buildQuery.ts
@@ -2,5 +2,13 @@ import { buildQueryContext } from '@superset-ui/chart';
 import ChartFormData from './ChartFormData';
 
 export default function buildQuery(formData: ChartFormData) {
-  return buildQueryContext(formData);
+  const queryContext = buildQueryContext(formData);
+
+  // Enforce time-series mode
+  queryContext.queries.forEach(query => {
+    const q = query;
+    q.is_timeseries = true;
+  });
+
+  return queryContext;
 }


### PR DESCRIPTION
🐛 Bug Fix

To ensure the output is grouped by time for time series. 

@conglei 