### PR TITLE
fix: disable lazy import for line chart and box plot

### DIFF
--- a/packages/superset-ui-preset-chart-xy/src/BoxPlot/BoxPlot.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/BoxPlot/BoxPlot.tsx
@@ -52,6 +52,9 @@ type Props = {
 export default class BoxPlot extends React.PureComponent<Props> {
   static defaultProps = defaultProps;
 
+  encoder: Encoder;
+  private createEncoder: () => void;
+
   constructor(props: Props) {
     super(props);
 
@@ -67,9 +70,6 @@ export default class BoxPlot extends React.PureComponent<Props> {
     this.encoder = createEncoder(this.props.encoding);
     this.renderChart = this.renderChart.bind(this);
   }
-
-  encoder: Encoder;
-  private createEncoder: () => void;
 
   renderChart(dim: Dimension) {
     const { width, height } = dim;

--- a/packages/superset-ui-preset-chart-xy/src/BoxPlot/BoxPlot.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/BoxPlot/BoxPlot.tsx
@@ -25,7 +25,7 @@ import { createSelector } from 'reselect';
 import createTooltip from './createTooltip';
 import XYChartLayout from '../utils/XYChartLayout';
 import WithLegend from '../components/WithLegend';
-import ChartLegend from '../components/ChartLegend';
+import ChartLegend from '../components/legend/ChartLegend';
 import Encoder, { ChannelTypes, Encoding, Outputs } from './Encoder';
 import { Dataset, PlainObject } from '../encodeable/types/Data';
 

--- a/packages/superset-ui-preset-chart-xy/src/BoxPlot/index.ts
+++ b/packages/superset-ui-preset-chart-xy/src/BoxPlot/index.ts
@@ -19,11 +19,12 @@
 import { ChartPlugin } from '@superset-ui/chart';
 import createMetadata from './createMetadata';
 import transformProps from './transformProps';
+import Chart from './BoxPlot';
 
 export default class BoxPlotChartPlugin extends ChartPlugin {
   constructor() {
     super({
-      loadChart: () => import('./BoxPlot'),
+      Chart,
       metadata: createMetadata(),
       transformProps,
     });

--- a/packages/superset-ui-preset-chart-xy/src/BoxPlot/legacy/index.ts
+++ b/packages/superset-ui-preset-chart-xy/src/BoxPlot/legacy/index.ts
@@ -19,11 +19,12 @@
 import { ChartPlugin } from '@superset-ui/chart';
 import createMetadata from '../createMetadata';
 import transformProps from './transformProps';
+import Chart from '../BoxPlot';
 
 export default class BoxPlotChartPlugin extends ChartPlugin {
   constructor() {
     super({
-      loadChart: () => import('../BoxPlot'),
+      Chart,
       metadata: createMetadata(true),
       transformProps,
     });

--- a/packages/superset-ui-preset-chart-xy/src/Line/index.ts
+++ b/packages/superset-ui-preset-chart-xy/src/Line/index.ts
@@ -3,12 +3,13 @@ import transformProps from './transformProps';
 import createMetadata from './createMetadata';
 import buildQuery from './buildQuery';
 import ChartFormData from './ChartFormData';
+import Chart from './Line';
 
 export default class LineChartPlugin extends ChartPlugin<ChartFormData> {
   constructor() {
     super({
       buildQuery,
-      loadChart: () => import('./Line'),
+      Chart,
       metadata: createMetadata(),
       transformProps,
     });

--- a/packages/superset-ui-preset-chart-xy/src/Line/legacy/index.ts
+++ b/packages/superset-ui-preset-chart-xy/src/Line/legacy/index.ts
@@ -1,11 +1,12 @@
 import { ChartPlugin } from '@superset-ui/chart';
 import transformProps from './transformProps';
 import createMetadata from '../createMetadata';
+import Chart from '../Line';
 
 export default class LineChartPlugin extends ChartPlugin {
   constructor() {
     super({
-      loadChart: () => import('../Line'),
+      Chart,
       metadata: createMetadata(true),
       transformProps,
     });


### PR DESCRIPTION
🏠 Internal

* Disable lazy `import` temporarily due to problem with downstream application. 
* Also fix broken build