### PR TITLE
 fix: gradient not working when y axis title has space

### DIFF
--- a/packages/superset-ui-preset-chart-xy/src/Line/Line.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/Line/Line.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable sort-keys, no-magic-numbers, complexity */
 
 import React, { PureComponent } from 'react';
+import { kebabCase, groupBy, flatMap, uniqueId, values } from 'lodash';
 import {
   AreaSeries,
   LinearGradient,
@@ -11,7 +12,7 @@ import {
 } from '@data-ui/xy-chart';
 import { chartTheme, ChartTheme } from '@data-ui/theme';
 import { Margin, Dimension } from '@superset-ui/dimension';
-import { groupBy, flatMap, uniqueId, values } from 'lodash';
+
 import { createSelector } from 'reselect';
 import createTooltip from './createTooltip';
 import XYChartLayout from '../utils/XYChartLayout';
@@ -95,7 +96,7 @@ class LineChart extends PureComponent<Props> {
       const firstDatum = seriesData[0];
       const key = fieldNames.map(f => firstDatum[f]).join(',');
       const series: Series = {
-        key: key.length === 0 ? channels.y.getTitle() : key,
+        key: kebabCase(key.length === 0 ? channels.y.definition.field : key),
         color: channels.color.encode(firstDatum, '#222'),
         fill: channels.fill.encode(firstDatum, false),
         strokeDasharray: channels.strokeDasharray.encode(firstDatum, ''),

--- a/packages/superset-ui-preset-chart-xy/src/Line/transformProps.ts
+++ b/packages/superset-ui-preset-chart-xy/src/Line/transformProps.ts
@@ -4,7 +4,7 @@ import { ChartProps } from '@superset-ui/chart';
 
 export default function transformProps(chartProps: ChartProps) {
   const { width, height, formData, payload } = chartProps;
-  const { encoding, margin } = formData;
+  const { encoding, margin, theme } = formData;
   const { data } = payload;
 
   return {
@@ -13,5 +13,6 @@ export default function transformProps(chartProps: ChartProps) {
     height,
     encoding,
     margin,
+    theme,
   };
 }

--- a/packages/superset-ui-preset-chart-xy/src/ScatterPlot/transformProps.ts
+++ b/packages/superset-ui-preset-chart-xy/src/ScatterPlot/transformProps.ts
@@ -4,7 +4,7 @@ import { ChartProps } from '@superset-ui/chart';
 
 export default function transformProps(chartProps: ChartProps) {
   const { width, height, formData, payload } = chartProps;
-  const { encoding, commonEncoding, margin } = formData;
+  const { encoding, commonEncoding, margin, theme } = formData;
   const { data } = payload;
 
   return {
@@ -14,5 +14,6 @@ export default function transformProps(chartProps: ChartProps) {
     encoding,
     commonEncoding,
     margin,
+    theme,
   };
 }


### PR DESCRIPTION
🐛 Bug Fix

* fix: gradient not working when y axis title has space
* fix: pass `theme` variable for line chart and scatter plot
