### PR TITLE
new(preset-chart-xy): Support `LegendRenderer` hook

### DIFF
--- a/packages/superset-ui-preset-chart-xy/src/Line/transformProps.ts
+++ b/packages/superset-ui-preset-chart-xy/src/Line/transformProps.ts
@@ -24,6 +24,7 @@ export default function transformProps(chartProps: ChartProps) {
 
   const fieldsFromHooks: (keyof HookProps)[] = [
     'TooltipRenderer',
+    'LegendRenderer',
     'LegendGroupRenderer',
     'LegendItemRenderer',
     'LegendItemMarkRenderer',


### PR DESCRIPTION
🏆 Enhancements

This PR updates the `preset-chart-xy` plugin to support the `LegendRenderer` hook, currently this is not `picked` from `chartProps`.

Trying to test this in another repo but `npm link` isn't behaving.
