### PR TITLE
fix: move series in front of xy gridlines

### DIFF
--- a/packages/superset-ui-preset-chart-xy/src/BoxPlot/BoxPlot.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/BoxPlot/BoxPlot.tsx
@@ -120,9 +120,9 @@ export default class BoxPlot extends React.PureComponent<Props> {
         xScale={convertScaleToDataUIScale(channels.x.scale!.config)}
         yScale={convertScaleToDataUIScale(channels.y.scale!.config)}
       >
-        {children}
         {layout.renderXAxis()}
         {layout.renderYAxis()}
+        {children}
       </XYChart>
     ));
   }

--- a/packages/superset-ui-preset-chart-xy/src/Line/Line.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/Line/Line.tsx
@@ -259,9 +259,9 @@ export default class LineChart extends PureComponent<Props> {
             xScale={convertScaleToDataUIScale(channels.x.scale!.config)}
             yScale={convertScaleToDataUIScale(channels.y.scale!.config)}
           >
-            {children}
             {layout.renderXAxis()}
             {layout.renderYAxis()}
+            {children}
             <CrossHair
               fullHeight
               strokeDasharray=""

--- a/packages/superset-ui-preset-chart-xy/src/ScatterPlot/ScatterPlot.tsx
+++ b/packages/superset-ui-preset-chart-xy/src/ScatterPlot/ScatterPlot.tsx
@@ -135,9 +135,9 @@ export default class ScatterPlot extends PureComponent<Props> {
         xScale={convertScaleToDataUIScale(channels.x.scale!.config)}
         yScale={convertScaleToDataUIScale(channels.y.scale!.config)}
       >
-        {children}
         {layout.renderXAxis()}
         {layout.renderYAxis()}
+        {children}
       </XYChart>
     ));
   }


### PR DESCRIPTION
🐛 Bug Fix

The series (line, scatter, boxplot) were rendered behind the gridlines. Move them in front

