### PR TITLE
fix: fixing tooltip for expanded area chart

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -559,7 +559,7 @@ function nvd3Vis(element, props) {
         chart.interactiveLayer.tooltip.contentGenerator(d =>
           generateRichLineTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),
         );
-      } else {
+      } else if (areaStackedStyle !== 'expand') {
         // area chart
         chart.interactiveLayer.tooltip.contentGenerator(d =>
           generateAreaChartTooltipContent(d, smartDateVerboseFormatter, yAxisFormatter),

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Area/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Area/Stories.jsx
@@ -42,4 +42,42 @@ export default [
     storyName: 'Stacked',
     storyPath: 'legacy-|preset-chart-nvd3|AreaChartPlugin',
   },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="area"
+        chartProps={{
+          datasource: {
+            verboseMap: {},
+          },
+          formData: {
+            bottomMargin: 'auto',
+            colorCcheme: 'd3Category10',
+            contribution: false,
+            groupby: ['region'],
+            lineInterpolation: 'linear',
+            metrics: ['sum__SP_POP_TOTL'],
+            richTooltip: true,
+            showBrush: 'auto',
+            showControls: false,
+            showLegend: true,
+            stackedStyle: 'expand',
+            vizType: 'area',
+            xAxisFormat: '%Y',
+            xAxisLabel: '',
+            xAxisShowminmax: false,
+            xTicksLayout: 'auto',
+            yAxisBounds: [null, null],
+            yAxisFormat: '.3s',
+            yLogScale: false,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'Expanded',
+    storyPath: 'legacy-|preset-chart-nvd3|AreaChartPlugin',
+  },
 ];


### PR DESCRIPTION
🐛 Bug Fix

[This PR](https://github.com/apache-superset/superset-ui-plugins/pull/27) added functionality for more data in the area chart rich tooltip, but those calculations don't make sense for the expanded chart. The expanded chart tooltip already shows % of total values and doesn't have a total line item. `generateAreaChartTooltipContent` shouldn't be called for `expand` stacked style.

![image](https://user-images.githubusercontent.com/817955/60525624-98e11180-9ca3-11e9-837a-c93a9dbfeb75.png)

@graceguo-supercat @etr2460 