### PR TITLE
fix: responsive y-axis on stacked charts

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -50,7 +50,6 @@ import {
   setAxisShowMaxMin,
   stringifyTimeRange,
   wrapTooltip,
-  computeYDomain,
 } from './utils';
 import {
   annotationLayerType,
@@ -613,24 +612,10 @@ function nvd3Vis(element, props) {
       const [min, max] = yAxisBounds;
       const hasCustomMin = isDefined(min) && !Number.isNaN(min);
       const hasCustomMax = isDefined(max) && !Number.isNaN(max);
-      let yMin;
-      let yMax;
       if (hasCustomMin && hasCustomMax) {
-        yMin = min;
-        yMax = max;
-      } else {
-        let [trueMin, trueMax] = [0, 1];
-        // These viz types can be stacked
-        if (isVizTypes(['area', 'bar', 'dist_bar'])) {
-          [trueMin, trueMax] = chart.yAxis.scale().domain();
-        } else {
-          [trueMin, trueMax] = computeYDomain(data);
-        }
-        yMin = hasCustomMin ? min : trueMin;
-        yMax = hasCustomMax ? max : trueMax;
+        chart.yDomain([min, max]);
+        chart.clipEdge(true);
       }
-      chart.yDomain([yMin, yMax]);
-      chart.clipEdge(true);
     }
 
     // align yAxis1 and yAxis2 ticks

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Area/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-preset-chart-nvd3/Area/Stories.jsx
@@ -61,6 +61,82 @@ export default [
             showBrush: 'auto',
             showControls: false,
             showLegend: true,
+            stackedStyle: 'stack',
+            vizType: 'area',
+            xAxisFormat: '%Y',
+            xAxisLabel: '',
+            xAxisShowminmax: false,
+            xTicksLayout: 'auto',
+            yAxisBounds: [0, 3000000000],
+            yAxisFormat: '.3s',
+            yLogScale: false,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'Stacked with yAxisBounds',
+    storyPath: 'legacy-|preset-chart-nvd3|AreaChartPlugin',
+  },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="area"
+        chartProps={{
+          datasource: {
+            verboseMap: {},
+          },
+          formData: {
+            bottomMargin: 'auto',
+            colorCcheme: 'd3Category10',
+            contribution: false,
+            groupby: ['region'],
+            lineInterpolation: 'linear',
+            metrics: ['sum__SP_POP_TOTL'],
+            richTooltip: true,
+            showBrush: 'auto',
+            showControls: false,
+            showLegend: true,
+            stackedStyle: 'stack',
+            vizType: 'area',
+            xAxisFormat: '%Y',
+            xAxisLabel: '',
+            xAxisShowminmax: false,
+            xTicksLayout: 'auto',
+            yAxisBounds: [1000000000, null],
+            yAxisFormat: '.3s',
+            yLogScale: false,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'Stacked with yAxisBounds min only',
+    storyPath: 'legacy-|preset-chart-nvd3|AreaChartPlugin',
+  },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="area"
+        chartProps={{
+          datasource: {
+            verboseMap: {},
+          },
+          formData: {
+            bottomMargin: 'auto',
+            colorCcheme: 'd3Category10',
+            contribution: false,
+            groupby: ['region'],
+            lineInterpolation: 'linear',
+            metrics: ['sum__SP_POP_TOTL'],
+            richTooltip: true,
+            showBrush: 'auto',
+            showControls: false,
+            showLegend: true,
             stackedStyle: 'expand',
             vizType: 'area',
             xAxisFormat: '%Y',
@@ -78,6 +154,44 @@ export default [
       />
     ),
     storyName: 'Expanded',
+    storyPath: 'legacy-|preset-chart-nvd3|AreaChartPlugin',
+  },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="area"
+        chartProps={{
+          datasource: {
+            verboseMap: {},
+          },
+          formData: {
+            bottomMargin: 'auto',
+            colorCcheme: 'd3Category10',
+            contribution: false,
+            groupby: ['region'],
+            lineInterpolation: 'linear',
+            metrics: ['sum__SP_POP_TOTL'],
+            richTooltip: true,
+            showBrush: 'auto',
+            showControls: true,
+            showLegend: true,
+            stackedStyle: 'stack',
+            vizType: 'area',
+            xAxisFormat: '%Y',
+            xAxisLabel: '',
+            xAxisShowminmax: false,
+            xTicksLayout: 'auto',
+            yAxisBounds: [null, null],
+            yAxisFormat: '.3s',
+            yLogScale: false,
+          },
+          height: 400,
+          payload: { data },
+          width: 400,
+        }}
+      />
+    ),
+    storyName: 'Controls Shown',
     storyPath: 'legacy-|preset-chart-nvd3|AreaChartPlugin',
   },
 ];


### PR DESCRIPTION
🐛 Bug Fix

It looks like https://github.com/apache-superset/superset-ui-plugins/pull/45 introduced a new bug where when unselecting series on stacked charts the y-axis wouldn't be responsive to fix the chart size. I've tested this fix with series selected and unselected, no yAxisBounds and yAxisBounded, and everything seems to work as intended.

However, it seems like this logic has been changed a lot lately, so I might be missing edge cases. Let me know if I should test anything else!

No y axis bounds:
<img width="416" alt="Screen Shot 2019-07-12 at 2 32 01 PM" src="https://user-images.githubusercontent.com/7409244/61160431-4fb76b80-a4b4-11e9-9648-d8b91975d19f.png">
<img width="417" alt="Screen Shot 2019-07-12 at 2 32 09 PM" src="https://user-images.githubusercontent.com/7409244/61160432-4fb76b80-a4b4-11e9-88ae-57c74fe203e8.png">

y axis bounds:
<img width="435" alt="Screen Shot 2019-07-12 at 2 32 20 PM" src="https://user-images.githubusercontent.com/7409244/61160436-5514b600-a4b4-11e9-9b9d-ce6532cbd745.png">
<img width="414" alt="Screen Shot 2019-07-12 at 2 32 31 PM" src="https://user-images.githubusercontent.com/7409244/61160437-5514b600-a4b4-11e9-9c12-c1069a7aef50.png">


cc: @williaster @khtruong @michellethomas @graceguo-supercat 