### PR TITLE
fix: disable lint error

### DIFF
--- a/packages/superset-ui-preset-chart-xy/src/encodeable/types/Axis.ts
+++ b/packages/superset-ui-preset-chart-xy/src/encodeable/types/Axis.ts
@@ -55,6 +55,7 @@ export interface WithAxis {
   axis?: XAxis | YAxis;
 }
 
+// eslint-disable-next-line import/prefer-default-export
 export function isAxis(axis: Axis | null | undefined | false): axis is Axis {
   return axis !== false && axis !== null && axis !== undefined;
 }


### PR DESCRIPTION
🐛 Bug Fix

It looks like this was failing because we the lint rule doesn't recognize the typescript exports in the file, so eslint thinks there's only one export and expects it to be a default export (see https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md).

This fixes the build

@kristw 