### PR TITLE
fix: nvd3 charts break on stateChange dispatch

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -654,7 +654,9 @@ function nvd3Vis(element, props) {
     applyYAxisBounds();
 
     // Also reapply on each state change to account for enabled/disabled series
-    chart.dispatch.on('stateChange.applyYAxisBounds', applyYAxisBounds);
+    if (chart.dispatch && chart.dispatch.stateChange) {
+      chart.dispatch.on('stateChange.applyYAxisBounds', applyYAxisBounds);
+    }
 
     // align yAxis1 and yAxis2 ticks
     if (isVizTypes(['dual_line', 'line_multi'])) {


### PR DESCRIPTION
🐛 Bug Fix
The change in https://github.com/apache-superset/superset-ui-plugins/pull/148 broke charts that don't have a `stateChange` dispatch event like the box plot. This fixes the issue.

Tested by opening all the charts (including box plot) in storybook and seeing them render

@kristw 