### PR TITLE
build: speed up storybook build

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -21,7 +21,7 @@
 import { kebabCase, throttle } from 'lodash';
 import d3 from 'd3';
 import nv from 'nvd3';
-import { parse as mathjsParse } from 'mathjs';
+import mathjs from 'mathjs';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { isDefined } from '@superset-ui/core';
@@ -819,7 +819,7 @@ function nvd3Vis(element, props) {
         // Formula annotations
         const formulas = activeAnnotationLayers
           .filter(a => a.annotationType === ANNOTATION_TYPES.FORMULA)
-          .map(a => ({ ...a, formula: mathjsParse(a.value) }));
+          .map(a => ({ ...a, formula: mathjs.parse(a.value) }));
 
         let xMax;
         let xMin;

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -21,7 +21,7 @@
 import { kebabCase, throttle } from 'lodash';
 import d3 from 'd3';
 import nv from 'nvd3';
-import mathjs from 'mathjs';
+import { parse as mathjsParse } from 'mathjs';
 import moment from 'moment';
 import PropTypes from 'prop-types';
 import { isDefined } from '@superset-ui/core';
@@ -819,7 +819,7 @@ function nvd3Vis(element, props) {
         // Formula annotations
         const formulas = activeAnnotationLayers
           .filter(a => a.annotationType === ANNOTATION_TYPES.FORMULA)
-          .map(a => ({ ...a, formula: mathjs.parse(a.value) }));
+          .map(a => ({ ...a, formula: mathjsParse(a.value) }));
 
         let xMax;
         let xMin;

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = async ({ config }) => {
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs|d3([-][a-z]+)?/;
+  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs|d3([-][a-z]+)?|[@]storybook/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -61,8 +61,10 @@ module.exports = async ({ config }) => {
     },
   };
 
-  console.log('process.env.RUNNING_CONTEXT', process.env.RUNNING_CONTEXT);
-  config.parellism = process.env.RUNNING_CONTEXT === 'netlify' ? 1 : 100;
+  if (process.env.RUNNING_CONTEXT === 'netlify') {
+    config.paralellism = 1;
+    config.devtool = false;
+  }
 
   return config;
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -26,6 +26,7 @@ module.exports = async ({ config }) => {
     ...config.resolve.alias,
     d3$: path.resolve(__dirname, '../../../node_modules/d3/d3.min.js'),
     nvd3$: path.resolve(__dirname, '../../../node_modules/nvd3/build/nv.d3.min.js'),
+    'datatables.net$': path.resolve(__dirname, '../../../node_modules/datatables.net/js/jquery.dataTables.min.js'),
   }
 
   config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = async ({ config }) => {
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs/;
+  config.module.noParse = /core[-]js|d3$|jquery|lodash|moment|mathjs/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,12 +22,12 @@ const SIBLING_PACKAGES_PATH_REGEXP = new RegExp(
 module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
-  config.resolve.alias = {
-    ...config.resolve.alias,
-    d3$: path.resolve(__dirname, '../../../node_modules/d3/d3.min.js'),
-    nvd3$: path.resolve(__dirname, '../../../node_modules/nvd3/build/nv.d3.min.js'),
-    'datatables.net$': path.resolve(__dirname, '../../../node_modules/datatables.net/js/jquery.dataTables.min.js'),
-  }
+  // config.resolve.alias = {
+  //   ...config.resolve.alias,
+  //   d3$: path.resolve(__dirname, '../../../node_modules/d3/d3.min.js'),
+  //   nvd3$: path.resolve(__dirname, '../../../node_modules/nvd3/build/nv.d3.min.js'),
+  //   'datatables.net$': path.resolve(__dirname, '../../../node_modules/datatables.net/js/jquery.dataTables.min.js'),
+  // }
 
   config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
   // Avoid parsing large libraries to speed up build
@@ -61,14 +61,9 @@ module.exports = async ({ config }) => {
     }],
   });
 
-  // config.optimization = {
-  //   splitChunks: {
-  //     chunks: 'async'
-  //   },
-  // };
-
   if (process.env.RUNNING_CONTEXT === 'netlify') {
     config.devtool = false;
+    config.cache = false;
   }
 
   return config;

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = async ({ config }) => {
   };
 
   if (process.env.RUNNING_CONTEXT === 'netlify') {
-    config.paralellism = 1;
+    config.parallelism = 1;
     config.devtool = false;
   }
 

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,10 +22,15 @@ const SIBLING_PACKAGES_PATH_REGEXP = new RegExp(
 module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    d3$: path.resolve(__dirname, '../../../node_modules/d3/d3.min.js'),
+    nvd3$: path.resolve(__dirname, '../../../node_modules/nvd3/build/nv.d3.min.js'),
+  }
 
   config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /^(d3|jquery|lodash|moment|mathjs|datamaps)$/;
+  config.module.noParse = /jquery|moment/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({
@@ -62,7 +67,6 @@ module.exports = async ({ config }) => {
   };
 
   if (process.env.RUNNING_CONTEXT === 'netlify') {
-    config.parallelism = 1;
     config.devtool = false;
   }
 

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const webpack = require('webpack');
 
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [
@@ -21,8 +22,9 @@ module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
+  config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /d3$|jquery|moment|mathjs|datamaps|datatables|^mapbox[-]gl/;
+  config.module.noParse = /^(d3|jquery|lodash|moment|mathjs|datamaps)$/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({
@@ -57,6 +59,8 @@ module.exports = async ({ config }) => {
       chunks: 'async'
     },
   };
+
+  console.log('config', config);
 
   return config;
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -2,9 +2,6 @@ const path = require('path');
 const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
 
-const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
-const smp = new SpeedMeasurePlugin();
-
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [
     ['@babel/preset-env', { useBuiltIns: 'entry' }],

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = async ({ config }) => {
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs|d3([-][a-z]+)?|[@]storybook/;
+  config.module.noParse = /core[-]js|jquery|moment|mathjs/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -8,6 +8,7 @@ const BABEL_TYPESCRIPT_OPTIONS = {
     '@babel/preset-typescript',
   ],
   plugins: [
+    'lodash',
     '@babel/plugin-proposal-object-rest-spread',
     '@babel/plugin-proposal-class-properties',
     '@babel/plugin-syntax-dynamic-import',
@@ -59,8 +60,6 @@ module.exports = async ({ config }) => {
       chunks: 'async'
     },
   };
-
-  console.log('config', config);
 
   return config;
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -1,4 +1,7 @@
 const path = require('path');
+const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
+
+const smp = new SpeedMeasurePlugin();
 
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [
@@ -21,7 +24,7 @@ module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
-  config.module.noParse = /core[-]js|lodash|moment|mathjs|d3[-].*/;
+  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs|d3([-].+)?/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({
@@ -57,5 +60,5 @@ module.exports = async ({ config }) => {
     },
   };
 
-  return config;
+  return smp.wrap(config);
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -1,5 +1,9 @@
 const path = require('path');
+const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
+
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+const smp = new SpeedMeasurePlugin();
 
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [
@@ -29,7 +33,7 @@ module.exports = async ({ config }) => {
     'datatables.net$': path.resolve(__dirname, '../../../node_modules/datatables.net/js/jquery.dataTables.min.js'),
   }
 
-  // config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
+  config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
   // Avoid parsing large libraries to speed up build
   config.module.noParse = /jquery|moment/;
 
@@ -53,6 +57,7 @@ module.exports = async ({ config }) => {
   });
 
   config.module.rules.push({
+    include: path.resolve(__dirname, '../storybook'),
     exclude: /node_modules/,
     test: /\.tsx?$/,
     use: [{
@@ -60,6 +65,17 @@ module.exports = async ({ config }) => {
       options: BABEL_TYPESCRIPT_OPTIONS,
     }],
   });
+
+  config.optimization = config.optimization || {};
+  config.optimization.splitChunks = {
+    chunks: 'async'
+  };
+  config.optimization.minimizer = [
+    new TerserPlugin({
+      parallel: true,
+      extractComments: true,
+    }),
+  ];
 
   if (process.env.RUNNING_CONTEXT === 'netlify') {
     config.devtool = false;

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -1,7 +1,4 @@
 const path = require('path');
-const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
-
-const smp = new SpeedMeasurePlugin();
 
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,7 +22,7 @@ module.exports = async ({ config }) => {
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /core[-]js|d3$|jquery|lodash|moment|mathjs/;
+  config.module.noParse = /d3$|jquery|moment|mathjs|datamaps|datatables|^mapbox[-]gl/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -1,7 +1,4 @@
 const path = require('path');
-const SpeedMeasurePlugin = require('speed-measure-webpack-plugin');
-
-const smp = new SpeedMeasurePlugin();
 
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [
@@ -24,7 +21,8 @@ module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
-  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs|d3([-].+)?/;
+  // Avoid parsing large libraries to speed up build
+  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs|d3([-][a-z]+)?/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({
@@ -60,5 +58,5 @@ module.exports = async ({ config }) => {
     },
   };
 
-  return smp.wrap(config);
+  return config;
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -61,5 +61,8 @@ module.exports = async ({ config }) => {
     },
   };
 
+  console.log('process.env.RUNNING_CONTEXT', process.env.RUNNING_CONTEXT);
+  config.parellism = process.env.RUNNING_CONTEXT === 'netlify' ? 1 : 100;
+
   return config;
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -21,6 +21,8 @@ module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
+  config.module.noParse = /core[-]js|lodash|moment|mathjs|d3[-].*/;
+
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({
     include: SIBLING_PACKAGES_PATH_REGEXP,
@@ -48,6 +50,12 @@ module.exports = async ({ config }) => {
       options: BABEL_TYPESCRIPT_OPTIONS,
     }],
   });
+
+  config.optimization = {
+    splitChunks: {
+      chunks: 'async'
+    },
+  };
 
   return config;
 };

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -1,4 +1,7 @@
 const path = require('path');
+const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+
+const smp = new SpeedMeasurePlugin();
 
 const BABEL_TYPESCRIPT_OPTIONS = {
   presets: [
@@ -22,7 +25,7 @@ module.exports = async ({ config }) => {
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
 
   // Avoid parsing large libraries to speed up build
-  config.module.noParse = /core[-]js|jquery|moment|mathjs/;
+  config.module.noParse = /core[-]js|jquery|lodash|moment|mathjs/;
 
   // To enable live debugging of other packages when referring to `src`
   config.module.rules.push({

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -22,14 +22,14 @@ const SIBLING_PACKAGES_PATH_REGEXP = new RegExp(
 module.exports = async ({ config }) => {
   config.resolve = config.resolve || {};
   config.resolve.extensions = ['.tsx', '.ts', '.jsx', '.js'];
-  // config.resolve.alias = {
-  //   ...config.resolve.alias,
-  //   d3$: path.resolve(__dirname, '../../../node_modules/d3/d3.min.js'),
-  //   nvd3$: path.resolve(__dirname, '../../../node_modules/nvd3/build/nv.d3.min.js'),
-  //   'datatables.net$': path.resolve(__dirname, '../../../node_modules/datatables.net/js/jquery.dataTables.min.js'),
-  // }
+  config.resolve.alias = {
+    ...config.resolve.alias,
+    d3$: path.resolve(__dirname, '../../../node_modules/d3/d3.min.js'),
+    nvd3$: path.resolve(__dirname, '../../../node_modules/nvd3/build/nv.d3.min.js'),
+    'datatables.net$': path.resolve(__dirname, '../../../node_modules/datatables.net/js/jquery.dataTables.min.js'),
+  }
 
-  config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
+  // config.plugins.push(new webpack.IgnorePlugin(/^\.\/locale$/, /moment$/));
   // Avoid parsing large libraries to speed up build
   config.module.noParse = /jquery|moment/;
 

--- a/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
+++ b/packages/superset-ui-plugins-demo/.storybook/webpack.config.js
@@ -61,11 +61,11 @@ module.exports = async ({ config }) => {
     }],
   });
 
-  config.optimization = {
-    splitChunks: {
-      chunks: 'async'
-    },
-  };
+  // config.optimization = {
+  //   splitChunks: {
+  //     chunks: 'async'
+  //   },
+  // };
 
   if (process.env.RUNNING_CONTEXT === 'netlify') {
     config.devtool = false;

--- a/packages/superset-ui-plugins-demo/package.json
+++ b/packages/superset-ui-plugins-demo/package.json
@@ -9,7 +9,6 @@
     "demo:build": "build-storybook -o _gh-pages",
     "demo:publish": "gh-pages -d _gh-pages",
     "deploy-demo": "npm run demo:clean && npm run demo:build && npm run demo:publish && npm run demo:clean",
-    "build:dll": "webpack --config library.webpack.config.js",
     "storybook": "start-storybook -p 9001"
   },
   "repository": {

--- a/packages/superset-ui-plugins-demo/package.json
+++ b/packages/superset-ui-plugins-demo/package.json
@@ -9,6 +9,7 @@
     "demo:build": "build-storybook -o _gh-pages",
     "demo:publish": "gh-pages -d _gh-pages",
     "deploy-demo": "npm run demo:clean && npm run demo:build && npm run demo:publish && npm run demo:clean",
+    "build:dll": "webpack --config library.webpack.config.js",
     "storybook": "start-storybook -p 9001"
   },
   "repository": {
@@ -46,7 +47,8 @@
     "@babel/core": "^7.4.3",
     "@babel/plugin-syntax-dynamic-import": "^7.2.0",
     "babel-loader": "^8.0.5",
-    "gh-pages": "^2.0.1"
+    "gh-pages": "^2.0.1",
+    "terser-webpack-plugin": "1.3.0"
   },
   "peerDependencies": {
     "@superset-ui/chart": "^0.11.13",

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-country-map/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-country-map/index.js
@@ -1,8 +1,8 @@
-import CountryMapChartPlugin from '../../../../superset-ui-legacy-plugin-chart-country-map';
-import Stories from './Stories';
+// import CountryMapChartPlugin from '../../../../superset-ui-legacy-plugin-chart-country-map';
+// import Stories from './Stories';
 
-new CountryMapChartPlugin().configure({ key: 'country-map' }).register();
+// new CountryMapChartPlugin().configure({ key: 'country-map' }).register();
 
-export default {
-  examples: [...Stories],
-};
+// export default {
+//   examples: [...Stories],
+// };

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-country-map/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-country-map/index.js
@@ -1,3 +1,5 @@
+// Disable temporarily
+
 // import CountryMapChartPlugin from '../../../../superset-ui-legacy-plugin-chart-country-map';
 // import Stories from './Stories';
 

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-map-box/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-map-box/index.js
@@ -1,8 +1,8 @@
-import MapBoxChartPlugin from '../../../../superset-ui-legacy-plugin-chart-map-box';
-import Stories from './Stories';
+// import MapBoxChartPlugin from '../../../../superset-ui-legacy-plugin-chart-map-box';
+// import Stories from './Stories';
 
-new MapBoxChartPlugin().configure({ key: 'map-box' }).register();
+// new MapBoxChartPlugin().configure({ key: 'map-box' }).register();
 
-export default {
-  examples: [...Stories],
-};
+// export default {
+//   examples: [...Stories],
+// };

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-map-box/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-map-box/index.js
@@ -1,3 +1,5 @@
+// Disable temporarily
+
 // import MapBoxChartPlugin from '../../../../superset-ui-legacy-plugin-chart-map-box';
 // import Stories from './Stories';
 

--- a/packages/superset-ui-plugins-demo/storybook/stories/preset-chart-xy/BoxPlot/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/preset-chart-xy/BoxPlot/index.js
@@ -1,5 +1,5 @@
-import { BoxPlotChartPlugin as LegacyBoxPlotChartPlugin } from '../../../../../superset-ui-preset-chart-xy/src/legacy';
-import { BoxPlotChartPlugin } from '../../../../../superset-ui-preset-chart-xy/src';
+import { BoxPlotChartPlugin as LegacyBoxPlotChartPlugin } from '../../../../../superset-ui-preset-chart-xy/esm/legacy';
+import { BoxPlotChartPlugin } from '../../../../../superset-ui-preset-chart-xy';
 import Stories from './stories/Basic';
 import LegacyStories from './stories/Legacy';
 import { BOX_PLOT_PLUGIN_LEGACY_TYPE, BOX_PLOT_PLUGIN_TYPE } from './constants';

--- a/packages/superset-ui-plugins-demo/storybook/stories/preset-chart-xy/Line/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/preset-chart-xy/Line/index.js
@@ -1,5 +1,5 @@
-import { LineChartPlugin as LegacyLineChartPlugin } from '../../../../../superset-ui-preset-chart-xy/src/legacy';
-import { LineChartPlugin } from '../../../../../superset-ui-preset-chart-xy/src';
+import { LineChartPlugin as LegacyLineChartPlugin } from '../../../../../superset-ui-preset-chart-xy/esm/legacy';
+import { LineChartPlugin } from '../../../../../superset-ui-preset-chart-xy';
 import BasicStories from './stories/basic';
 import FlushStories from './stories/flush';
 import QueryStories from './stories/query';

--- a/packages/superset-ui-plugins-demo/storybook/stories/preset-chart-xy/ScatterPlot/index.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/preset-chart-xy/ScatterPlot/index.js
@@ -1,5 +1,5 @@
-import { ScatterPlotPlugin as LegacyScatterPlotPlugin } from '../../../../../superset-ui-preset-chart-xy/src/legacy';
-import { ScatterPlotPlugin } from '../../../../../superset-ui-preset-chart-xy/src';
+import { ScatterPlotPlugin as LegacyScatterPlotPlugin } from '../../../../../superset-ui-preset-chart-xy/esm/legacy';
+import { ScatterPlotPlugin } from '../../../../../superset-ui-preset-chart-xy';
 import BasicStories from './stories/basic';
 import BubbleStories from './stories/bubble';
 import LegacyStories from './stories/legacy';


### PR DESCRIPTION
🏠 Internal

* Avoid parsing large libraries and reduce optimization aggressiveness to trade for speed and hopefully reduce netlify timeout.
* Disable storybooks for MapBox and CountryMap which are not actively developed and included large dependencies.