### PR TITLE
Fix D3 format for some viz types

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-big-number/src/BigNumber/transformProps.js
+++ b/packages/superset-ui-legacy-preset-chart-big-number/src/BigNumber/transformProps.js
@@ -82,7 +82,18 @@ export default function transformProps(chartProps) {
     className = 'negative';
   }
 
-  const formatValue = getNumberFormatter(yAxisFormat);
+  // SUP-146
+  let metricFormat = yAxisFormat;
+  if (!yAxisFormat) {
+    for (let x = 0; x < chartProps.datasource.metrics.length; x++) {
+      if (chartProps.datasource.metrics[x].metric_name == metric) {
+        metricFormat = chartProps.datasource.metrics[x].d3format;
+      }
+    }
+  }
+
+  const formatValue = getNumberFormatter(metricFormat);
+  // End SUP-146
 
   return {
     width,

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/transformProps.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/transformProps.js
@@ -84,6 +84,36 @@ export default function transformProps(chartProps) {
       }))
     : rawData;
 
+  // SUP-146
+  let d3NumberFormat;
+  let d3YAxisFormat;
+  let d3YAxis2Format;
+  if (chartProps.formData.vizType == "pie") {
+      for (let x = 0; x < chartProps.datasource.metrics.length; x++) {
+          if (chartProps.datasource.metrics[x].metric_name == chartProps.formData.metric) {
+              d3NumberFormat = chartProps.datasource.metrics[x].d3format;
+              break;
+          }
+      }
+  } else if (chartProps.formData.vizType == "dual_line") {
+      for (let x = 0; x < chartProps.datasource.metrics.length; x++) {
+          if (chartProps.datasource.metrics[x].metric_name == chartProps.formData.metric) {
+              d3YAxisFormat = chartProps.datasource.metrics[x].d3format;
+          } else if (chartProps.datasource.metrics[x].metric_name == chartProps.formData.metric2) {
+              d3YAxis2Format = chartProps.datasource.metrics[x].d3format;
+          }
+      }
+  } else if (chartProps.formData.vizType == "line" ||chartProps.formData.vizType == "dist_bar" ||
+             chartProps.formData.vizType == "bar" || chartProps.formData.vizType == "area") {
+      for (let x = 0; x < chartProps.datasource.metrics.length; x++) {
+          if (chartProps.datasource.metrics[x].metric_name == chartProps.formData.metrics[0]) {
+              d3YAxisFormat = chartProps.datasource.metrics[x].d3format;
+              break;
+          }
+      }
+  }
+  //End SUP-146
+
   return {
     width,
     height,
@@ -103,7 +133,7 @@ export default function transformProps(chartProps) {
     leftMargin,
     lineInterpolation,
     maxBubbleSize: parseInt(maxBubbleSize, 10),
-    numberFormat,
+    numberFormat: d3NumberFormat ? d3NumberFormat : numberFormat,
     onBrushEnd: isTruthy(sendTimeRange)
       ? timeRange => {
           onAddFilter('__time_range', timeRange, false, true);
@@ -128,8 +158,8 @@ export default function transformProps(chartProps) {
     xField: x,
     xIsLogScale: xLogScale,
     xTicksLayout,
-    yAxisFormat,
-    yAxis2Format,
+    yAxisFormat: d3YAxisFormat ? d3YAxisFormat : yAxisFormat,
+    yAxis2Format: d3YAxis2Format ? d3YAxis2Format : yAxis2Format,
     yAxisBounds,
     yAxisLabel,
     yAxisShowMinMax: yAxisShowminmax,


### PR DESCRIPTION
Some viz types don't honor the predefined D3 formats users enter for metrics. This change fixes this for a handful of viz types.