### PR TITLE
fix(plugin-chart-table): move react to peerdependency

### DIFF
--- a/packages/superset-ui-plugin-chart-table/package.json
+++ b/packages/superset-ui-plugin-chart-table/package.json
@@ -27,13 +27,13 @@
   },
   "dependencies": {
     "@airbnb/lunar": "^2.16.0",
-    "@airbnb/lunar-icons": "^2.1.4",
-    "react": "^16.8.6"
+    "@airbnb/lunar-icons": "^2.1.4"
   },
   "peerDependencies": {
     "@superset-ui/chart": "^0.11.14",
     "@superset-ui/number-format": "^0.11.14",
     "@superset-ui/time-format": "^0.11.14",
-    "@superset-ui/translation": "^0.11.9"
+    "@superset-ui/translation": "^0.11.9",
+    "react": "^16.8.6"
   }
 }


### PR DESCRIPTION
🐛 Bug Fix

`react` should be listed as `peerDependencies`.