### PR TITLE
fix(tablevis): Set proper width for each column

### DIFF
--- a/packages/superset-ui-plugin-chart-table/package.json
+++ b/packages/superset-ui-plugin-chart-table/package.json
@@ -31,6 +31,7 @@
   },
   "peerDependencies": {
     "@superset-ui/chart": "^0.12.0",
+    "@superset-ui/dimension": "^0.12.0",
     "@superset-ui/number-format": "^0.12.0",
     "@superset-ui/query": "^0.12.0",
     "@superset-ui/time-format": "^0.12.0",

--- a/packages/superset-ui-plugin-chart-table/package.json
+++ b/packages/superset-ui-plugin-chart-table/package.json
@@ -31,7 +31,6 @@
   },
   "peerDependencies": {
     "@superset-ui/chart": "^0.12.0",
-    "@superset-ui/dimension": "^0.12.0",
     "@superset-ui/number-format": "^0.12.0",
     "@superset-ui/query": "^0.12.0",
     "@superset-ui/time-format": "^0.12.0",

--- a/packages/superset-ui-plugin-chart-table/src/Table.tsx
+++ b/packages/superset-ui-plugin-chart-table/src/Table.tsx
@@ -9,6 +9,7 @@ import { getRenderer, ColumnType, heightType, Cell } from './renderer';
 type Props = {
   data: ParentRow[];
   height: number;
+  width: number;
   alignPositiveNegative?: boolean;
   colorPositiveNegative?: boolean;
   columns: ColumnType[];
@@ -33,6 +34,10 @@ const defaultProps = {
 };
 
 const SEARCH_BAR_HEIGHT = 40;
+
+const CHAR_WIDTH = 10;
+
+const MAX_COLUMN_WIDTH = 500;
 
 export type TableProps = Props & Readonly<typeof defaultProps>;
 
@@ -148,6 +153,7 @@ class TableVis extends React.PureComponent<InternalTableProps, TableState> {
       alignPositiveNegative,
       colorPositiveNegative,
       height,
+      width,
       tableFilter,
       styles,
       includeSearch,
@@ -176,6 +182,18 @@ class TableVis extends React.PureComponent<InternalTableProps, TableState> {
       }
     });
 
+    const keys = dataToRender && dataToRender.length > 0 ? Object.keys(dataToRender[0].data) : [];
+    let calculatedWidth = 0;
+    keys.forEach(key => {
+      const maxLength = Math.max(...data.map(d => String(d.data[key]).length), key.length);
+      columnMetadata[key] = {
+        maxWidth: MAX_COLUMN_WIDTH,
+        width: maxLength * CHAR_WIDTH,
+        ...columnMetadata[key],
+      };
+      calculatedWidth += Math.min(maxLength * CHAR_WIDTH, MAX_COLUMN_WIDTH);
+    });
+
     const tableHeight = includeSearch ? height - SEARCH_BAR_HEIGHT : height;
 
     return (
@@ -199,12 +217,13 @@ class TableVis extends React.PureComponent<InternalTableProps, TableState> {
         )}
         <DataTable
           data={dataToRender}
-          keys={dataToRender && dataToRender.length > 0 ? Object.keys(dataToRender[0].data) : []}
+          keys={keys}
           columnMetadata={columnMetadata}
           zebra
           rowHeight={heightType}
           renderers={renderers}
           height={tableHeight}
+          width={Math.max(calculatedWidth, width)}
         />
       </div>
     );

--- a/packages/superset-ui-plugin-chart-table/src/Table.tsx
+++ b/packages/superset-ui-plugin-chart-table/src/Table.tsx
@@ -4,6 +4,7 @@ import Text from '@airbnb/lunar/lib/components/Text';
 import Input from '@airbnb/lunar/lib/components/Input';
 import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
 import { Renderers, ParentRow, ColumnMetadata } from '@airbnb/lunar/lib/components/DataTable/types';
+import { getMultipleTextDimensions } from '@superset-ui/dimension';
 import { getRenderer, ColumnType, heightType, Cell } from './renderer';
 
 type Props = {
@@ -34,8 +35,6 @@ const defaultProps = {
 };
 
 const SEARCH_BAR_HEIGHT = 40;
-
-const CHAR_WIDTH = 10;
 
 const MAX_COLUMN_WIDTH = 500;
 
@@ -185,13 +184,18 @@ class TableVis extends React.PureComponent<InternalTableProps, TableState> {
     const keys = dataToRender && dataToRender.length > 0 ? Object.keys(dataToRender[0].data) : [];
     let calculatedWidth = 0;
     keys.forEach(key => {
-      const maxLength = Math.max(...data.map(d => String(d.data[key]).length), key.length);
+      // const maxLength = Math.max(...data.map(d => String(d.data[key]).length), key.length);
+      const dimensions = getMultipleTextDimensions({
+        style: { fontSize: 20 },
+        texts: data.map(d => String(d.data[key])).concat([key]),
+      });
+      const columnWidth = Math.max(...dimensions.map(dim => dim.width));
       columnMetadata[key] = {
         maxWidth: MAX_COLUMN_WIDTH,
-        width: maxLength * CHAR_WIDTH,
+        width: columnWidth,
         ...columnMetadata[key],
       };
-      calculatedWidth += Math.min(maxLength * CHAR_WIDTH, MAX_COLUMN_WIDTH);
+      calculatedWidth += Math.min(columnWidth, MAX_COLUMN_WIDTH);
     });
 
     const tableHeight = includeSearch ? height - SEARCH_BAR_HEIGHT : height;

--- a/packages/superset-ui-plugin-chart-table/src/Table.tsx
+++ b/packages/superset-ui-plugin-chart-table/src/Table.tsx
@@ -4,7 +4,6 @@ import Text from '@airbnb/lunar/lib/components/Text';
 import Input from '@airbnb/lunar/lib/components/Input';
 import withStyles, { WithStylesProps } from '@airbnb/lunar/lib/composers/withStyles';
 import { Renderers, ParentRow, ColumnMetadata } from '@airbnb/lunar/lib/components/DataTable/types';
-import { getMultipleTextDimensions } from '@superset-ui/dimension';
 import { getRenderer, ColumnType, heightType, Cell } from './renderer';
 
 type Props = {
@@ -35,6 +34,8 @@ const defaultProps = {
 };
 
 const SEARCH_BAR_HEIGHT = 40;
+
+const CHAR_WIDTH = 10;
 
 const MAX_COLUMN_WIDTH = 500;
 
@@ -184,18 +185,13 @@ class TableVis extends React.PureComponent<InternalTableProps, TableState> {
     const keys = dataToRender && dataToRender.length > 0 ? Object.keys(dataToRender[0].data) : [];
     let calculatedWidth = 0;
     keys.forEach(key => {
-      // const maxLength = Math.max(...data.map(d => String(d.data[key]).length), key.length);
-      const dimensions = getMultipleTextDimensions({
-        style: { fontSize: 20 },
-        texts: data.map(d => String(d.data[key])).concat([key]),
-      });
-      const columnWidth = Math.max(...dimensions.map(dim => dim.width));
+      const maxLength = Math.max(...data.map(d => String(d.data[key]).length), key.length);
       columnMetadata[key] = {
         maxWidth: MAX_COLUMN_WIDTH,
-        width: columnWidth,
+        width: maxLength * CHAR_WIDTH,
         ...columnMetadata[key],
       };
-      calculatedWidth += Math.min(columnWidth, MAX_COLUMN_WIDTH);
+      calculatedWidth += Math.min(maxLength * CHAR_WIDTH, MAX_COLUMN_WIDTH);
     });
 
     const tableHeight = includeSearch ? height - SEARCH_BAR_HEIGHT : height;

--- a/packages/superset-ui-plugin-chart-table/src/legacy/transformProps.ts
+++ b/packages/superset-ui-plugin-chart-table/src/legacy/transformProps.ts
@@ -26,7 +26,7 @@ import processData from '../processData';
 const NOOP = () => {};
 
 export default function transformProps(chartProps: ChartProps) {
-  const { height, datasource, initialValues, formData, hooks, queryData } = chartProps;
+  const { height, datasource, initialValues, formData, hooks, queryData, width } = chartProps;
 
   const { onAddFilter = NOOP } = hooks;
 
@@ -67,6 +67,7 @@ export default function transformProps(chartProps: ChartProps) {
 
   return {
     height,
+    width,
     data: processedData,
     alignPositiveNegative: alignPn,
     colorPositiveNegative: colorPn,

--- a/packages/superset-ui-plugin-chart-table/src/transformProps.ts
+++ b/packages/superset-ui-plugin-chart-table/src/transformProps.ts
@@ -86,7 +86,7 @@ function transformData(data: PlainObject[], formData: PlainObject) {
 const NOOP = () => {};
 
 export default function transformProps(chartProps: ChartProps) {
-  const { height, datasource, initialValues, formData, hooks, queryData } = chartProps;
+  const { height, width, datasource, initialValues, formData, hooks, queryData } = chartProps;
 
   const { onAddFilter = NOOP } = hooks;
 
@@ -137,5 +137,6 @@ export default function transformProps(chartProps: ChartProps) {
     orderDesc,
     pageLength: pageLength && parseInt(pageLength, 10),
     tableFilter,
+    width,
   };
 }

--- a/packages/superset-ui-plugins-demo/storybook/stories/plugin-chart-table/Stories.jsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/plugin-chart-table/Stories.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { SuperChart } from '@superset-ui/chart';
 import dataLegacy from './dataLegacy';
 import data from './data';
+import bigData from './bigData';
 
 export default [
   {
@@ -93,6 +94,33 @@ export default [
       />
     ),
     storyName: 'TableFilter',
+    storyPath: 'plugin-chart-table|TableChartPlugin',
+  },
+  {
+    renderStory: () => (
+      <SuperChart
+        chartType="table2"
+        key="bigTable"
+        datasource={{
+          columnFormats: {},
+          verboseMap: {},
+        }}
+        formData={{
+          alignPn: true,
+          colorPn: true,
+          includeSearch: true,
+          metrics: [],
+          orderDesc: true,
+          pageLength: 0,
+          percentMetrics: [],
+          tableFilter: true,
+          tableTimestampFormat: '%Y-%m-%d %H:%M:%S',
+          timeseriesLimitMetric: null,
+        }}
+        queryData={{ data: bigData }}
+      />
+    ),
+    storyName: 'BigTable',
     storyPath: 'plugin-chart-table|TableChartPlugin',
   },
 ];

--- a/packages/superset-ui-plugins-demo/storybook/stories/plugin-chart-table/bigData.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/plugin-chart-table/bigData.js
@@ -1,21 +1,21 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-magic-numbers */
 /* eslint-disable sort-keys */
-const longString = `The quick brown fox jumps over the lazy dog`;
-const shortString = 'Superset';
+const LONG_STRING = `The quick brown fox jumps over the lazy dog`;
+const SHORT_STRING = 'Superset';
 
-const rowCount = 30;
-const columnCount = 20;
+const ROW_COUNT = 30;
+const COLUMN_COUNT = 20;
 
-export const keys = Array(columnCount)
+export const keys = Array(COLUMN_COUNT)
   .fill(0)
   .map((_, i) => `Column Name ${i}`);
 
 const item = {};
 keys.forEach(key => {
-  item[key] = Math.random() < 0.5 ? longString : shortString;
+  item[key] = Math.random() < 0.5 ? LONG_STRING : SHORT_STRING;
 });
 
-export default Array(rowCount)
+export default Array(ROW_COUNT)
   .fill(0)
   .map(_ => ({ ...item }));

--- a/packages/superset-ui-plugins-demo/storybook/stories/plugin-chart-table/bigData.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/plugin-chart-table/bigData.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-unused-vars */
+/* eslint-disable no-magic-numbers */
+/* eslint-disable sort-keys */
+const longString = `The quick brown fox jumps over the lazy dog`;
+const shortString = 'Superset';
+
+const rowCount = 30;
+const columnCount = 20;
+
+export const keys = Array(columnCount)
+  .fill(0)
+  .map((_, i) => `Column Name ${i}`);
+
+const item = {};
+keys.forEach(key => {
+  item[key] = Math.random() < 0.5 ? longString : shortString;
+});
+
+export default Array(rowCount)
+  .fill(0)
+  .map(_ => ({ ...item }));


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix
This PR is to fix the issue of the readability of table vis when there are too many columns in the table. 

![image](https://user-images.githubusercontent.com/2024960/64278647-1a525b80-cf02-11e9-870e-ebba64a2de87.png)

Before rendering the table, we will estimate the width for each column according to the max string length (max width is set to be 500px). 

🏠 Internal
