### PR TITLE
fix: remove redundant target from sankey tooltip

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-sankey/src/Sankey.js
+++ b/packages/superset-ui-legacy-plugin-chart-sankey/src/Sankey.js
@@ -115,7 +115,6 @@ function Sankey(element, props) {
         '<br/>',
         `<span class='emph'>${Number.isFinite(targetPercent) ? targetPercent : '--'}%</span> of `,
         d.target.name,
-        'target',
         '</div>',
       ].join('');
     }


### PR DESCRIPTION
🐛 Bug Fix

Remove redundant `target` word from sankey tooltip. Fixes https://github.com/apache/incubator-superset/issues/8192 FYI: @lilila