### PR TITLE
fix: Line not hidden after legend selection

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -1080,13 +1080,15 @@ function nvd3Vis(element, props) {
           .call(chart);
 
         // Display styles for Time Series Annotations
-        d3.selectAll('.slice_container .nv-timeseries-annotation-layer.showMarkerstrue .nv-point')
-          .style('stroke-opacity', 1)
-          .style('fill-opacity', 1);
-        d3.selectAll('.slice_container .nv-timeseries-annotation-layer.hideLinetrue').style(
-          'stroke-width',
-          0,
-        );
+        chart.dispatch.on("renderEnd.timeseries-annotation", function(){
+          d3.selectAll('.slice_container .nv-timeseries-annotation-layer.showMarkerstrue .nv-point')
+            .style('stroke-opacity', 1)
+            .style('fill-opacity', 1);
+          d3.selectAll('.slice_container .nv-timeseries-annotation-layer.hideLinetrue').style(
+            'stroke-width',
+            0,
+          );
+        });
       }
     }
 

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -1080,7 +1080,7 @@ function nvd3Vis(element, props) {
           .call(chart);
 
         // Display styles for Time Series Annotations
-        chart.dispatch.on("renderEnd.timeseries-annotation", function(){
+        chart.dispatch.on('renderEnd.timeseries-annotation', () => {
           d3.selectAll('.slice_container .nv-timeseries-annotation-layer.showMarkerstrue .nv-point')
             .style('stroke-opacity', 1)
             .style('fill-opacity', 1);


### PR DESCRIPTION
🐛 Bug Fix
This PR fixes a bug in superset Line chart time series annotation. The bug is when you select an annotation time series and deselect it to show all the time series, the **show markers** and **hide line** properties are not honoured.
