### PR TITLE
fix: remove deprecated package storybook__addon-knobs.

### DIFF
--- a/packages/superset-ui-plugins-demo/package.json
+++ b/packages/superset-ui-plugins-demo/package.json
@@ -39,7 +39,6 @@
     "@storybook/react": "^5.0.9",
     "@types/react": "^16.8.8",
     "@types/storybook__react": "3.0.7",
-    "@types/storybook__addon-knobs": "^5.0.0",
     "bootstrap": "^4.3.1",
     "react": "^16.6.0",
     "storybook-addon-jsx": "^7.1.0"


### PR DESCRIPTION
The storybook addon knobs has been deprecated. That PR address build failures related to the error through during executing `yarn install` command  

🐛 Bug Fix