### PR TITLE
build(fix): fix storybook lib dependency and node version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - '10.10'
+  - '10.15'
 
 cache:
   - npm: true

--- a/packages/superset-ui-plugins-demo/package.json
+++ b/packages/superset-ui-plugins-demo/package.json
@@ -39,7 +39,6 @@
     "@storybook/react": "^5.0.9",
     "@types/react": "^16.8.8",
     "@types/storybook__react": "3.0.7",
-    "@types/storybook__addon-knobs": "^5.0.0",
     "bootstrap": "^4.3.1",
     "react": "^16.6.0",
     "storybook-addon-jsx": "^7.1.0"


### PR DESCRIPTION
💔 Breaking Changes

🏆 Enhancements

📜 Documentation

🐛 Bug Fix
This PR is to:

1. remove `@types/storybook__addon-knobs` since typing is supported natively.

2. bumping node version to `10.15` since `eslint6.5` requires it. 

🏠 Internal
