### PR TITLE
chore: bump @data-ui/xy-chart@^0.0.84

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-big-number/package.json
+++ b/packages/superset-ui-legacy-preset-chart-big-number/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@data-ui/xy-chart": "^0.0.82",
+    "@data-ui/xy-chart": "^0.0.84",
     "d3-color": "^1.2.3",
     "prop-types": "^15.6.2",
     "shortid": "^2.2.14"

--- a/packages/superset-ui-legacy-preset-chart-nvd3/package.json
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@data-ui/xy-chart": "^0.0.82",
+    "@data-ui/xy-chart": "^0.0.84",
     "d3": "^3.5.17",
     "d3-tip": "^0.9.1",
     "dompurify": "^2.0.6",

--- a/packages/superset-ui-preset-chart-xy/package.json
+++ b/packages/superset-ui-preset-chart-xy/package.json
@@ -29,8 +29,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@data-ui/theme": "^0.0.82",
-    "@data-ui/xy-chart": "^0.0.82",
+    "@data-ui/theme": "^0.0.84",
+    "@data-ui/xy-chart": "^0.0.84",
     "@types/d3-scale": "^2.1.1",
     "@vx/axis": "^0.0.192",
     "@vx/group": "^0.0.192",


### PR DESCRIPTION
🐛 Bug Fix
This bumps `@data-ui/xy-chart` to the latest, which contains the latest [`@vx/responsive`](https://github.com/williaster/data-ui/pull/193) + [`@vx/text`](https://github.com/williaster/data-ui/pull/194) which have some [🐛 bug fixes for measuring invisible text](https://github.com/hshoff/vx/blob/master/CHANGELOG.md#v00175). 

Hoping to fix an issue in a consumer of this package.