### PR TITLE
fixing overflow issue

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.css
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.css
@@ -121,3 +121,13 @@
 .superset-legacy-chart-nvd3-tr-total {
   font-weight: bold;
 }
+
+/* START tooltip styles - these prevent long column names from overflowing the tooltip */
+.nvtooltip tbody tr:first-child td{
+  white-space: nowrap;
+  font-weight: bold;
+}
+.nvtooltip tbody tr:not(:first-child) td:nth-child(2){
+  word-break: break-word;
+}
+/* END tooltip styles */


### PR DESCRIPTION
This addresses Superset issue 8669:
https://github.com/apache/incubator-superset/issues/8669

It also makes the headers bold, which hopefully looks better to folks.

Before:
![image](https://user-images.githubusercontent.com/812905/69991568-cbb25e80-14fc-11ea-810d-f449c7c2d936.png)

After:
![image](https://user-images.githubusercontent.com/812905/69991501-a7ef1880-14fc-11ea-8553-6251e7870ca9.png)