### PR TITLE
fix: apply margins in nvd3

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-parallel-coordinates/src/vendor/parcoords/d3.parcoords.js
+++ b/packages/superset-ui-legacy-plugin-chart-parallel-coordinates/src/vendor/parcoords/d3.parcoords.js
@@ -1759,10 +1759,9 @@ module.exports = function(config) {
       var svg = pc.selection.select('svg').select('g#arcs'),
         id = arc.dims.i,
         points = [arc.p2, arc.p3],
-        line = svg.selectAll('line#arc-' + id).data([
-          { p1: arc.p1, p2: arc.p2 },
-          { p1: arc.p1, p2: arc.p3 },
-        ]),
+        line = svg
+          .selectAll('line#arc-' + id)
+          .data([{ p1: arc.p1, p2: arc.p2 }, { p1: arc.p1, p2: arc.p3 }]),
         circles = svg.selectAll('circle#arc-' + id).data(points),
         drag = d3.behavior.drag(),
         path = svg.selectAll('path#arc-' + id).data([arc]);

--- a/packages/superset-ui-legacy-plugin-chart-sankey-loop/src/SankeyLoop.js
+++ b/packages/superset-ui-legacy-plugin-chart-sankey-loop/src/SankeyLoop.js
@@ -86,10 +86,7 @@ function SankeyLoop(element, props) {
 
   const layout = sankey()
     .nodeId(d => d.id)
-    .extent([
-      [margin.left, margin.top],
-      [innerWidth, innerHeight],
-    ]);
+    .extent([[margin.left, margin.top], [innerWidth, innerHeight]]);
 
   const diagram = sankeyDiagram()
     .nodeTitle(d => d.name)

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -800,7 +800,9 @@ function nvd3Vis(element, props) {
                     key,
                     color: a.color,
                     strokeWidth: a.width,
-                    classed: `${a.opacity} ${a.style} nv-timeseries-annotation-layer showMarkers${a.showMarkers} hideLine${a.hideLine}`,
+                    classed: `${a.opacity} ${a.style} nv-timeseries-annotation-layer showMarkers${
+                      a.showMarkers
+                    } hideLine${a.hideLine}`,
                   };
                 }),
               ),
@@ -822,6 +824,7 @@ function nvd3Vis(element, props) {
       }
 
       // render chart
+      chart.margin(margins);
       svg
         .datum(data)
         .transition()
@@ -832,10 +835,7 @@ function nvd3Vis(element, props) {
 
       // On scroll, hide (not remove) tooltips so they can reappear on hover.
       // Throttle to only 4x/second.
-      window.addEventListener(
-        'scroll',
-        throttle(() => hideTooltips(false), 250),
-      );
+      window.addEventListener('scroll', throttle(() => hideTooltips(false), 250));
 
       // The below code should be run AFTER rendering because chart is updated in call()
       if (isTimeSeries && activeAnnotationLayers.length > 0) {

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-map-box/data.js
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-map-box/data.js
@@ -5513,10 +5513,7 @@ export default {
   clusteringRadius: '60',
   pointRadiusUnit: 'Pixels',
   globalOpacity: 1,
-  bounds: [
-    [-122.4753019, 37.7101158],
-    [-122.3675625, 37.829124799999995],
-  ],
+  bounds: [[-122.4753019, 37.7101158], [-122.3675625, 37.829124799999995]],
   renderWhileDragging: true,
   tooltip: null,
   color: 'rgb(0, 122, 135)',

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-pivot-table/Stories.tsx
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-pivot-table/Stories.tsx
@@ -20,10 +20,7 @@ export default [
         datasource={datasource}
         queryData={{
           data: {
-            columns: [
-              ['sum__num', 'other'],
-              ['sum__num', 'All'],
-            ],
+            columns: [['sum__num', 'other'], ['sum__num', 'All']],
             html:
               '<table border="1" class="dataframe dataframe table table-striped table-bordered table-condensed table-hover">\n  <thead>\n    <tr>\n      <th></th>\n      <th colspan="2" halign="left">sum__num</th>\n    </tr>\n    <tr>\n      <th>state</th>\n      <th>other</th>\n      <th>All</th>\n    </tr>\n    <tr>\n      <th>name</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>Christopher</th>\n      <td>803607</td>\n      <td>803607</td>\n    </tr>\n    <tr>\n      <th>David</th>\n      <td>673992</td>\n      <td>673992</td>\n    </tr>\n    <tr>\n      <th>James</th>\n      <td>749686</td>\n      <td>749686</td>\n    </tr>\n    <tr>\n      <th>Jennifer</th>\n      <td>587540</td>\n      <td>587540</td>\n    </tr>\n    <tr>\n      <th>John</th>\n      <td>638450</td>\n      <td>638450</td>\n    </tr>\n    <tr>\n      <th>Joshua</th>\n      <td>548044</td>\n      <td>548044</td>\n    </tr>\n    <tr>\n      <th>Matthew</th>\n      <td>608212</td>\n      <td>608212</td>\n    </tr>\n    <tr>\n      <th>Michael</th>\n      <td>1047996</td>\n      <td>1047996</td>\n    </tr>\n    <tr>\n      <th>Robert</th>\n      <td>575592</td>\n      <td>575592</td>\n    </tr>\n    <tr>\n      <th>William</th>\n      <td>574464</td>\n      <td>574464</td>\n    </tr>\n    <tr>\n      <th>All</th>\n      <td>6807583</td>\n      <td>6807583</td>\n    </tr>\n  </tbody>\n</table>',
           },
@@ -46,10 +43,7 @@ export default [
         datasource={datasource}
         queryData={{
           data: {
-            columns: [
-              ['sum__num', 'other'],
-              ['sum__num', 'All'],
-            ],
+            columns: [['sum__num', 'other'], ['sum__num', 'All']],
             html:
               '<table border="1" class="dataframe dataframe table table-striped table-bordered table-condensed table-hover">\n  <thead>\n    <tr>\n      <th></th>\n      <th colspan="2" halign="left">sum__num</th>\n    </tr>\n    <tr>\n      <th>state</th>\n      <th>other</th>\n      <th>All</th>\n    </tr>\n    <tr>\n      <th>name</th>\n      <th></th>\n      <th></th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>Christopher</th>\n      <td>null</td>\n      <td>803607</td>\n    </tr>\n    <tr>\n      <th>David</th>\n      <td>null</td>\n      <td>673992</td>\n    </tr>\n    <tr>\n      <th>James</th>\n      <td>749686</td>\n      <td>null</td>\n    </tr>\n    <tr>\n      <th>Jennifer</th>\n      <td>587540</td>\n      <td>null</td>\n    </tr>\n    <tr>\n      <th>John</th>\n      <td>638450</td>\n      <td>638450</td>\n    </tr>\n    <tr>\n      <th>Joshua</th>\n      <td>null</td>\n      <td>548044</td>\n    </tr>\n    <tr>\n      <th>Matthew</th>\n      <td>608212</td>\n      <td>608212</td>\n    </tr>\n    <tr>\n      <th>Michael</th>\n      <td>1047996</td>\n      <td>1047996</td>\n    </tr>\n    <tr>\n      <th>Robert</th>\n      <td>575592</td>\n      <td>575592</td>\n    </tr>\n    <tr>\n      <th>William</th>\n      <td>574464</td>\n      <td>574464</td>\n    </tr>\n    <tr>\n      <th>All</th>\n      <td>6807583</td>\n      <td>6807583</td>\n    </tr>\n  </tbody>\n</table>',
           },

--- a/packages/superset-ui-preset-chart-xy/src/encodeable/AbstractEncoder.ts
+++ b/packages/superset-ui-preset-chart-xy/src/encodeable/AbstractEncoder.ts
@@ -10,7 +10,7 @@ import ChannelEncoder from './ChannelEncoder';
 type AllChannelEncoders<Encoding extends Record<string, MayBeArray<ChannelDef>>> = {
   readonly [k in keyof Encoding]: Encoding[k] extends any[]
     ? ChannelEncoder<Unarray<Encoding[k]>>[]
-    : ChannelEncoder<Unarray<Encoding[k]>>;
+    : ChannelEncoder<Unarray<Encoding[k]>>
 };
 
 export default abstract class AbstractEncoder<

--- a/packages/superset-ui-preset-chart-xy/src/encodeable/types/Data.ts
+++ b/packages/superset-ui-preset-chart-xy/src/encodeable/types/Data.ts
@@ -1,5 +1,5 @@
 export type PlainObject<Key extends string = string, Value extends any = any> = {
-  [key in Key]: Value;
+  [key in Key]: Value
 };
 
 export type Dataset<T extends string = string> = Partial<PlainObject<T>>[];


### PR DESCRIPTION
🐛 Bug Fix

The NVD3 visualization does a bunch of operations on the margin object, depending on the visualization parameters. For example, if we're showing the labels on bars we need to increase the top margin by 24px so that it doesn't overlap with the legend:

```javascript
      if (showBarValue) {
        // Add more margin to avoid label colliding with legend.
        margins.top += 24;
      }
```

The problem is that the `margins` object is never assigned to the chart. This PR fixes it.

Before:

![Screen Shot 2019-12-02 at 3 30 32 PM](https://user-images.githubusercontent.com/1534870/70003830-412c2800-1519-11ea-8df6-5298e7673972.png)

After:

<img width="1680" alt="Screen Shot 2019-12-02 at 3 30 01 PM" src="https://user-images.githubusercontent.com/1534870/70003837-45f0dc00-1519-11ea-8062-41eb3e51db11.png">

This PR fixes https://github.com/apache/incubator-superset/issues/8480.