### PR TITLE
fix: Sunburst chart now respects/prefers Metric's D3 Format setting

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/Sunburst.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/Sunburst.js
@@ -42,9 +42,7 @@ const propTypes = {
 };
 
 function metricLabel(metric) {
-  return typeof metric === 'string' || metric instanceof String
-    ? metric
-    : metric.label;
+  return typeof metric === 'string' || metric instanceof String ? metric : metric.label;
 }
 
 // Given a node in a partition layout, return an array of all of its ancestor
@@ -72,8 +70,7 @@ function Sunburst(element, props) {
   const containerHeight = height;
   const breadcrumbHeight = containerHeight * 0.085;
   const visWidth = containerWidth - margin.left - margin.right;
-  const visHeight =
-    containerHeight - margin.top - margin.bottom - breadcrumbHeight;
+  const visHeight = containerHeight - margin.top - margin.bottom - breadcrumbHeight;
   const radius = Math.min(visWidth, visHeight) / 2;
 
   let colorByCategory = true; // color by category if primary/secondary metrics match
@@ -137,25 +134,20 @@ function Sunburst(element, props) {
     points.push('0,0');
     points.push(`${breadcrumbDims.width},0`);
     points.push(
-      `${breadcrumbDims.width +
-        breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`,
+      `${breadcrumbDims.width + breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`,
     );
     points.push(`${breadcrumbDims.width},${breadcrumbDims.height}`);
     points.push(`0,${breadcrumbDims.height}`);
     if (i > 0) {
       // Leftmost breadcrumb; don't include 6th vertex.
-      points.push(
-        `${breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`,
-      );
+      points.push(`${breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`);
     }
 
     return points.join(' ');
   }
 
   function updateBreadcrumbs(sequenceArray, percentageString) {
-    const g = breadcrumbs
-      .selectAll('g')
-      .data(sequenceArray, d => d.name + d.depth);
+    const g = breadcrumbs.selectAll('g').data(sequenceArray, d => d.name + d.depth);
 
     // Add breadcrumb and label for entering nodes.
     const entering = g.enter().append('svg:g');
@@ -163,9 +155,7 @@ function Sunburst(element, props) {
     entering
       .append('svg:polygon')
       .attr('points', breadcrumbPoints)
-      .style('fill', d =>
-        colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1),
-      );
+      .style('fill', d => (colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1)));
 
     entering
       .append('svg:text')
@@ -174,9 +164,7 @@ function Sunburst(element, props) {
       .attr('dy', '0.85em')
       .style('fill', d => {
         // Make text white or black based on the lightness of the background
-        const col = d3.hsl(
-          colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1),
-        );
+        const col = d3.hsl(colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1));
 
         return col.l < 0.5 ? 'white' : 'black';
       })
@@ -187,8 +175,7 @@ function Sunburst(element, props) {
     // Set position for entering and updating nodes.
     g.attr(
       'transform',
-      (d, i) =>
-        `translate(${i * (breadcrumbDims.width + breadcrumbDims.spacing)}, 0)`,
+      (d, i) => `translate(${i * (breadcrumbDims.width + breadcrumbDims.spacing)}, 0)`,
     );
 
     // Remove exiting nodes.
@@ -197,11 +184,7 @@ function Sunburst(element, props) {
     // Now move and update the percentage at the end.
     breadcrumbs
       .select('.end-label')
-      .attr(
-        'x',
-        (sequenceArray.length + 0.5) *
-          (breadcrumbDims.width + breadcrumbDims.spacing),
-      )
+      .attr('x', (sequenceArray.length + 0.5) * (breadcrumbDims.width + breadcrumbDims.spacing))
       .attr('y', breadcrumbDims.height / 2)
       .attr('dy', '0.35em')
       .text(percentageString);
@@ -216,14 +199,10 @@ function Sunburst(element, props) {
     const parentOfD = sequenceArray[sequenceArray.length - 2] || null;
 
     const absolutePercentage = (d.m1 / totalSize).toPrecision(3);
-    const conditionalPercentage = parentOfD
-      ? (d.m1 / parentOfD.m1).toPrecision(3)
-      : null;
+    const conditionalPercentage = parentOfD ? (d.m1 / parentOfD.m1).toPrecision(3) : null;
 
     const absolutePercString = formatPerc(absolutePercentage);
-    const conditionalPercString = parentOfD
-      ? formatPerc(conditionalPercentage)
-      : '';
+    const conditionalPercString = parentOfD ? formatPerc(conditionalPercentage) : '';
 
     // 3 levels of text if inner-most level, 4 otherwise
     const yOffsets = ['-25', '7', '35', '60'];
@@ -265,9 +244,7 @@ function Sunburst(element, props) {
       .text(
         metricsMatch
           ? ''
-          : `${metricLabel(metrics[1])}/${metricLabel(
-              metrics[0],
-            )}: ${formatPerc(d.m2 / d.m1)}`,
+          : `${metricLabel(metrics[1])}/${metricLabel(metrics[0])}: ${formatPerc(d.m2 / d.m1)}`,
       );
 
     // Reset and fade all the segments.
@@ -331,8 +308,7 @@ function Sunburst(element, props) {
         const children = currentNode.children || [];
         const nodeName = levels[level].toString();
         // If the next node has the name '0', it will
-        const isLeafNode =
-          level >= levels.length - 1 || levels[level + 1] === 0;
+        const isLeafNode = level >= levels.length - 1 || levels[level + 1] === 0;
         let childNode;
         let currChild;
 
@@ -441,9 +417,7 @@ function Sunburst(element, props) {
       .attr('display', d => (d.depth ? null : 'none'))
       .attr('d', arc)
       .attr('fill-rule', 'evenodd')
-      .style('fill', d =>
-        colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1),
-      )
+      .style('fill', d => (colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1)))
       .style('opacity', 1)
       .on('mouseenter', mouseenter);
 

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/Sunburst.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/Sunburst.js
@@ -32,6 +32,7 @@ const propTypes = {
   width: PropTypes.number,
   height: PropTypes.number,
   colorScheme: PropTypes.string,
+  numberFormat: PropTypes.string,
   metrics: PropTypes.arrayOf(
     PropTypes.oneOfType([
       PropTypes.string,
@@ -41,7 +42,9 @@ const propTypes = {
 };
 
 function metricLabel(metric) {
-  return typeof metric === 'string' || metric instanceof String ? metric : metric.label;
+  return typeof metric === 'string' || metric instanceof String
+    ? metric
+    : metric.label;
 }
 
 // Given a node in a partition layout, return an array of all of its ancestor
@@ -61,7 +64,7 @@ function getAncestors(node) {
 function Sunburst(element, props) {
   const container = d3.select(element);
   container.classed('superset-legacy-chart-sunburst', true);
-  const { data, width, height, colorScheme, metrics } = props;
+  const { data, width, height, colorScheme, metrics, numberFormat } = props;
 
   // vars with shared scope within this function
   const margin = { top: 10, right: 5, bottom: 10, left: 5 };
@@ -69,7 +72,8 @@ function Sunburst(element, props) {
   const containerHeight = height;
   const breadcrumbHeight = containerHeight * 0.085;
   const visWidth = containerWidth - margin.left - margin.right;
-  const visHeight = containerHeight - margin.top - margin.bottom - breadcrumbHeight;
+  const visHeight =
+    containerHeight - margin.top - margin.bottom - breadcrumbHeight;
   const radius = Math.min(visWidth, visHeight) / 2;
 
   let colorByCategory = true; // color by category if primary/secondary metrics match
@@ -97,7 +101,9 @@ function Sunburst(element, props) {
     .innerRadius(d => Math.sqrt(d.y))
     .outerRadius(d => Math.sqrt(d.y + d.dy));
 
-  const formatNum = getNumberFormatter(NumberFormats.SI_3_DIGIT);
+  const formatNum = numberFormat
+    ? getNumberFormatter(numberFormat)
+    : getNumberFormatter(NumberFormats.SI_3_DIGIT);
   const formatPerc = getNumberFormatter(NumberFormats.PERCENT_3_POINT);
 
   container.select('svg').remove();
@@ -131,20 +137,25 @@ function Sunburst(element, props) {
     points.push('0,0');
     points.push(`${breadcrumbDims.width},0`);
     points.push(
-      `${breadcrumbDims.width + breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`,
+      `${breadcrumbDims.width +
+        breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`,
     );
     points.push(`${breadcrumbDims.width},${breadcrumbDims.height}`);
     points.push(`0,${breadcrumbDims.height}`);
     if (i > 0) {
       // Leftmost breadcrumb; don't include 6th vertex.
-      points.push(`${breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`);
+      points.push(
+        `${breadcrumbDims.tipTailWidth},${breadcrumbDims.height / 2}`,
+      );
     }
 
     return points.join(' ');
   }
 
   function updateBreadcrumbs(sequenceArray, percentageString) {
-    const g = breadcrumbs.selectAll('g').data(sequenceArray, d => d.name + d.depth);
+    const g = breadcrumbs
+      .selectAll('g')
+      .data(sequenceArray, d => d.name + d.depth);
 
     // Add breadcrumb and label for entering nodes.
     const entering = g.enter().append('svg:g');
@@ -152,7 +163,9 @@ function Sunburst(element, props) {
     entering
       .append('svg:polygon')
       .attr('points', breadcrumbPoints)
-      .style('fill', d => (colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1)));
+      .style('fill', d =>
+        colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1),
+      );
 
     entering
       .append('svg:text')
@@ -161,7 +174,9 @@ function Sunburst(element, props) {
       .attr('dy', '0.85em')
       .style('fill', d => {
         // Make text white or black based on the lightness of the background
-        const col = d3.hsl(colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1));
+        const col = d3.hsl(
+          colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1),
+        );
 
         return col.l < 0.5 ? 'white' : 'black';
       })
@@ -172,7 +187,8 @@ function Sunburst(element, props) {
     // Set position for entering and updating nodes.
     g.attr(
       'transform',
-      (d, i) => `translate(${i * (breadcrumbDims.width + breadcrumbDims.spacing)}, 0)`,
+      (d, i) =>
+        `translate(${i * (breadcrumbDims.width + breadcrumbDims.spacing)}, 0)`,
     );
 
     // Remove exiting nodes.
@@ -181,7 +197,11 @@ function Sunburst(element, props) {
     // Now move and update the percentage at the end.
     breadcrumbs
       .select('.end-label')
-      .attr('x', (sequenceArray.length + 0.5) * (breadcrumbDims.width + breadcrumbDims.spacing))
+      .attr(
+        'x',
+        (sequenceArray.length + 0.5) *
+          (breadcrumbDims.width + breadcrumbDims.spacing),
+      )
       .attr('y', breadcrumbDims.height / 2)
       .attr('dy', '0.35em')
       .text(percentageString);
@@ -196,10 +216,14 @@ function Sunburst(element, props) {
     const parentOfD = sequenceArray[sequenceArray.length - 2] || null;
 
     const absolutePercentage = (d.m1 / totalSize).toPrecision(3);
-    const conditionalPercentage = parentOfD ? (d.m1 / parentOfD.m1).toPrecision(3) : null;
+    const conditionalPercentage = parentOfD
+      ? (d.m1 / parentOfD.m1).toPrecision(3)
+      : null;
 
     const absolutePercString = formatPerc(absolutePercentage);
-    const conditionalPercString = parentOfD ? formatPerc(conditionalPercentage) : '';
+    const conditionalPercString = parentOfD
+      ? formatPerc(conditionalPercentage)
+      : '';
 
     // 3 levels of text if inner-most level, 4 otherwise
     const yOffsets = ['-25', '7', '35', '60'];
@@ -241,7 +265,9 @@ function Sunburst(element, props) {
       .text(
         metricsMatch
           ? ''
-          : `${metricLabel(metrics[1])}/${metricLabel(metrics[0])}: ${formatPerc(d.m2 / d.m1)}`,
+          : `${metricLabel(metrics[1])}/${metricLabel(
+              metrics[0],
+            )}: ${formatPerc(d.m2 / d.m1)}`,
       );
 
     // Reset and fade all the segments.
@@ -305,7 +331,8 @@ function Sunburst(element, props) {
         const children = currentNode.children || [];
         const nodeName = levels[level].toString();
         // If the next node has the name '0', it will
-        const isLeafNode = level >= levels.length - 1 || levels[level + 1] === 0;
+        const isLeafNode =
+          level >= levels.length - 1 || levels[level + 1] === 0;
         let childNode;
         let currChild;
 
@@ -414,7 +441,9 @@ function Sunburst(element, props) {
       .attr('display', d => (d.depth ? null : 'none'))
       .attr('d', arc)
       .attr('fill-rule', 'evenodd')
-      .style('fill', d => (colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1)))
+      .style('fill', d =>
+        colorByCategory ? colorFn(d.name) : colorScale(d.m2 / d.m1),
+      )
       .style('opacity', 1)
       .on('mouseenter', mouseenter);
 

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/Sunburst.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/Sunburst.js
@@ -98,9 +98,7 @@ function Sunburst(element, props) {
     .innerRadius(d => Math.sqrt(d.y))
     .outerRadius(d => Math.sqrt(d.y + d.dy));
 
-  const formatNum = numberFormat
-    ? getNumberFormatter(numberFormat)
-    : getNumberFormatter(NumberFormats.SI_3_DIGIT);
+  const formatNum = getNumberFormatter(numberFormat || NumberFormats.SI_3_DIGIT);
   const formatPerc = getNumberFormatter(NumberFormats.PERCENT_3_POINT);
 
   container.select('svg').remove();

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
@@ -30,11 +30,12 @@ export default function transformProps(chartProps) {
   };
 
   if (datasource && datasource.metrics) {
-    datasource.metrics.forEach(metricEntry => {
-      if (metricEntry.metric_name === formData.metric && metricEntry.d3format) {
-        Object.assign(returnProps, { numberFormat: metricEntry.d3format });
-      }
-    });
+    const metricWithFormat = datasource.metrics.find(
+      ({ metric_name: metricName, d3format }) => metricName === formData.metric && d3format,
+    );
+    if (metricWithFormat) {
+      Object.assign(returnProps, { numberFormat: metricWithFormat.d3format });
+    }
   }
 
   return returnProps;

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
@@ -21,7 +21,7 @@ export default function transformProps(chartProps) {
   const { width, height, formData, queryData, datasource } = chartProps;
   const { colorScheme, metric, secondaryMetric } = formData;
 
-  let returnProps = {
+  const returnProps = {
     width,
     height,
     data: queryData.data,
@@ -29,12 +29,13 @@ export default function transformProps(chartProps) {
     metrics: [metric, secondaryMetric],
   };
 
-  if (chartProps.datasource && chartProps.datasource.metrics) {
-    chartProps.datasource.metrics.forEach(metric => {
-      if (metric.metric_name == formData.metric && metric.d3format) {
-        Object.assign(returnProps, { numberFormat: metric.d3format });
+  if (datasource && datasource.metrics) {
+    datasource.metrics.forEach(metricEntry => {
+      if (metricEntry.metric_name === formData.metric && metricEntry.d3format) {
+        Object.assign(returnProps, { numberFormat: metricEntry.d3format });
       }
     });
   }
+
   return returnProps;
 }

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
@@ -18,14 +18,24 @@
  */
 /* eslint-disable sort-keys */
 export default function transformProps(chartProps) {
-  const { width, height, formData, queryData } = chartProps;
+  const { width, height, formData, queryData, datasource } = chartProps;
   const { colorScheme, metric, secondaryMetric } = formData;
 
-  return {
+  let returnProps = {
     width,
     height,
     data: queryData.data,
     colorScheme,
-    metrics: [metric, secondaryMetric],
+    metrics: [metric, secondaryMetric]
   };
+
+  if (chartProps.datasource && chartProps.datasource.metrics) {
+    chartProps.datasource.metrics.forEach(metric => {
+      if (metric.metric_name == formData.metric && metric.d3format) {
+        Object.assign(returnProps, { numberFormat: metric.d3format });
+      }
+    });
+  }
+  console.warn("!!!", returnProps);
+  return returnProps;
 }

--- a/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
+++ b/packages/superset-ui-legacy-plugin-chart-sunburst/src/transformProps.js
@@ -26,7 +26,7 @@ export default function transformProps(chartProps) {
     height,
     data: queryData.data,
     colorScheme,
-    metrics: [metric, secondaryMetric]
+    metrics: [metric, secondaryMetric],
   };
 
   if (chartProps.datasource && chartProps.datasource.metrics) {
@@ -36,6 +36,5 @@ export default function transformProps(chartProps) {
       }
     });
   }
-  console.warn("!!!", returnProps);
   return returnProps;
 }


### PR DESCRIPTION
🐛 Bug Fix

Sunburst chart wasn't paying any attention to the datasource Metric's `D3 Format` setting when populated. In this PR, that setting will OVERRIDE the plugin's automatic formatting normally used. 

I'm submitting this one separately since it may be contentious, because the viz plugin has no "Format" input to override the Metric's D3 Format. This may cause some small amount of fallout.

Using a goofy format with .....dots.... to illustrate the point in these screenshots.

Before:
![image](https://user-images.githubusercontent.com/812905/70093543-79913c00-15d5-11ea-9ec7-030b9dbe2a7b.png)

After:
![image](https://user-images.githubusercontent.com/812905/70093479-56ff2300-15d5-11ea-9a44-8bd773238bf7.png)

Reviewers
@mistercrunch @etr2460 