### PR TITLE
fix: Replace unsafe lifecycle methods

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
+++ b/packages/superset-ui-legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
@@ -59,8 +59,7 @@ class TTestTable extends React.Component {
     };
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  UNSAFE_componentWillMount() {
+  componentDidMount() {
     const { control } = this.state;
     this.computeTTest(control); // initially populate table
   }

--- a/packages/superset-ui-legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
+++ b/packages/superset-ui-legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
@@ -60,7 +60,7 @@ class TTestTable extends React.Component {
   }
 
   // eslint-disable-next-line react/no-deprecated
-  componentWillMount() {
+  UNSAFE_componentWillMount() {
     const { control } = this.state;
     this.computeTTest(control); // initially populate table
   }

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
@@ -70,9 +70,9 @@ class LineMulti extends React.Component {
 
   shouldComponentUpdate(nextProps) {
     const { rawFormData } = this.props;
-    const { rawFormData: nextrawFormData } = nextProps;
+    const { rawFormData: nextRawFormData } = nextProps;
     const { queryData } = this.state;
-    if (!queryData || !isEqual(rawFormData, nextrawFormData)) {
+    if (!queryData || !isEqual(rawFormData, nextRawFormData)) {
       return true;
     }
 

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
@@ -66,7 +66,7 @@ class LineMulti extends React.Component {
   }
 
   // eslint-disable-next-line react/no-deprecated
-  componentWillReceiveProps(nextProps) {
+  UNSAFE_componentWillReceiveProps(nextProps) {
     this.loadData(nextProps);
   }
 

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
@@ -77,7 +77,6 @@ class LineMulti extends React.Component {
     }
 
     return false;
-    // return false;
   }
 
   componentDidUpdate() {

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/LineMulti/LineMulti.jsx
@@ -20,6 +20,7 @@
 import d3 from 'd3';
 import React from 'react';
 import PropTypes from 'prop-types';
+import { isEqual } from 'lodash';
 import { getExploreLongUrl } from '../vendor/superset/exploreUtils';
 import ReactNVD3 from '../ReactNVD3';
 import transformProps from '../transformProps';
@@ -30,6 +31,8 @@ const propTypes = {
   annotationData: PropTypes.object,
   datasource: PropTypes.object,
   formData: PropTypes.object,
+  queryData: PropTypes.object,
+  rawFormData: PropTypes.object,
   hooks: PropTypes.shape({
     onAddFilter: PropTypes.func,
     onError: PropTypes.func,
@@ -58,16 +61,27 @@ function getJson(url) {
 class LineMulti extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { queryData: [] };
+    this.state = { queryData: false };
   }
 
   componentDidMount() {
     this.loadData(this.props);
   }
 
-  // eslint-disable-next-line react/no-deprecated
-  UNSAFE_componentWillReceiveProps(nextProps) {
-    this.loadData(nextProps);
+  shouldComponentUpdate(nextProps) {
+    const { rawFormData } = this.props;
+    const { rawFormData: nextrawFormData } = nextProps;
+    const { queryData } = this.state;
+    if (!queryData || !isEqual(rawFormData, nextrawFormData)) {
+      return true;
+    }
+
+    return false;
+    // return false;
+  }
+
+  componentDidUpdate() {
+    this.loadData(this.props);
   }
 
   loadData(props) {
@@ -81,8 +95,6 @@ class LineMulti extends React.Component {
       prefixMetricWithSliceName,
       timeRange,
     } = formData;
-
-    this.setState({ queryData: [] });
 
     // fetch data from all the charts
     const subslices = [


### PR DESCRIPTION
🐛 Bug Fix

There were warnings about a couple of unsafe lifecycle methods happening. For one of them, I just renamed the method as the warning suggests to stop it from barking. For the other, I updated it to the suggested lifecycle method, and all seems to work well.