### PR TITLE
fix: TTestTable viz had className error, and broken CSS styling

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
+++ b/packages/superset-ui-legacy-plugin-chart-paired-t-test/src/TTestTable.jsx
@@ -214,7 +214,7 @@ class TTestTable extends React.Component {
       values.push(
         <Td
           key={numGroups + 3}
-          className={this.getSignificance(i)}
+          className={this.getSignificance(i).toString()}
           column="significant"
           data={this.getSignificance(i)}
         />,


### PR DESCRIPTION
🐛 Bug Fix

There was a method returning a boolean used as a className, causing two issues:
1) The console was barking about using the boolean at all
2) The CSS for .true and .false classes was not being applied for lack of a string className.

This easy peasy fix addresses both issues.

Before:
![image](https://user-images.githubusercontent.com/812905/70117762-11fddf80-161b-11ea-9190-2c669833fdef.png)

After:
![image](https://user-images.githubusercontent.com/812905/70117730-001c3c80-161b-11ea-8cbf-11e3f9bd7ad9.png)
