### PR TITLE
fix: JS exception: Cannot read property 'dispatch' of undefined

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 *.log
 *.map
 *.min.js
+.*.swp
 
 babel.config.js
 build/

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -454,14 +454,16 @@ function nvd3Vis(element, props) {
     }
 
     if (canShowBrush && onBrushEnd !== NOOP) {
-      chart.focus.dispatch.on('brush', event => {
-        const timeRange = stringifyTimeRange(event.extent);
-        if (timeRange) {
-          event.brush.on('brushend', () => {
-            onBrushEnd(timeRange);
-          });
-        }
-      });
+      if (chart.focus) {
+        chart.focus.dispatch.on('brush', event => {
+          const timeRange = stringifyTimeRange(event.extent);
+          if (timeRange) {
+            event.brush.on('brushend', () => {
+              onBrushEnd(timeRange);
+            });
+          }
+        });
+      }
     }
 
     if (chart.xAxis && chart.xAxis.staggerLabels) {
@@ -969,22 +971,24 @@ function nvd3Vis(element, props) {
               }
 
               // update annotation positions on brush event
-              chart.focus.dispatch.on('onBrush.event-annotation', () => {
-                annotations
-                  .selectAll('line')
-                  .data(records)
-                  .attr({
-                    x1: d => xScale(new Date(d[e.timeColumn])),
-                    y1: 0,
-                    x2: d => xScale(new Date(d[e.timeColumn])),
-                    y2: annotationHeight,
-                    opacity: d => {
-                      const x = xScale(new Date(d[e.timeColumn]));
+              if (chart.focus) {
+                chart.focus.dispatch.on('onBrush.event-annotation', () => {
+                  annotations
+                    .selectAll('line')
+                    .data(records)
+                    .attr({
+                      x1: d => xScale(new Date(d[e.timeColumn])),
+                      y1: 0,
+                      x2: d => xScale(new Date(d[e.timeColumn])),
+                      y2: annotationHeight,
+                      opacity: d => {
+                        const x = xScale(new Date(d[e.timeColumn]));
 
-                      return x > 0 && x < chartWidth ? 1 : 0;
-                    },
-                  });
-              });
+                        return x > 0 && x < chartWidth ? 1 : 0;
+                      },
+                    });
+                });
+              }
             });
 
           // Interval annotations
@@ -1058,20 +1062,22 @@ function nvd3Vis(element, props) {
               }
 
               // update annotation positions on brush event
-              chart.focus.dispatch.on('onBrush.interval-annotation', () => {
-                annotations
-                  .selectAll('rect')
-                  .data(records)
-                  .attr({
-                    x: d => xScale(new Date(d[e.timeColumn])),
-                    width: d => {
-                      const x1 = xScale(new Date(d[e.timeColumn]));
-                      const x2 = xScale(new Date(d[e.intervalEndColumn]));
+              if (chart.focus) {
+                chart.focus.dispatch.on('onBrush.interval-annotation', () => {
+                  annotations
+                    .selectAll('rect')
+                    .data(records)
+                    .attr({
+                      x: d => xScale(new Date(d[e.timeColumn])),
+                      width: d => {
+                        const x1 = xScale(new Date(d[e.timeColumn]));
+                        const x2 = xScale(new Date(d[e.intervalEndColumn]));
 
-                      return x2 - x1;
-                    },
-                  });
-              });
+                        return x2 - x1;
+                      },
+                    });
+                });
+              }
             });
         }
 


### PR DESCRIPTION
🐛 Bug Fix

Sometimes chart took longer time to render, and annotation layer is rendered before chart is ready. In this case, when the annotation layer tried to attach event handler for brush events, it will cause JS exception because chart.focus object is not created:
<img width="1388" alt="Screen Shot 2019-12-04 at 2 58 57 PM" src="https://user-images.githubusercontent.com/27990562/70188897-c0029b80-16a6-11ea-9015-7431b574f622.png">

This error will make chart section blank, and cannot apply annotation at all.
