### PR TITLE
fix: add container css for interval type annotation

### DIFF
--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.css
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.css
@@ -166,9 +166,9 @@
 
 .d3-tip.nv-event-annotation-layer-table::after {
   content: '\25BC';
-  font-size: 22px;
+  font-size: 14px;
   color: #484848;
   position: absolute;
-  bottom: -23px;
-  left: 84px;
+  bottom: -14px;
+  left: 94px;
 }

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.css
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.css
@@ -153,3 +153,22 @@
   font-size: 14px;
   font-weight: normal;
 }
+
+.d3-tip.nv-event-annotation-layer-table {
+  width: 200px;
+  border-radius: 2px;
+  background-color: #484848;
+  fill-opacity: 0.6;
+  margin: 8px;
+  padding: 8px;
+  color: #fff;
+}
+
+.d3-tip.nv-event-annotation-layer-table::after {
+  content: '\25BC';
+  font-size: 22px;
+  color: #484848;
+  position: absolute;
+  bottom: -23px;
+  left: 84px;
+}

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/NVD3Vis.js
@@ -972,7 +972,10 @@ function nvd3Vis(element, props) {
                 .attr('class', `nv-event-annotation-layer-${index}`);
               const aColor = e.color || getColor(cleanColorInput(e.name), colorScheme);
 
-              const tip = tipFactory(e);
+              const tip = tipFactory({
+                ...e,
+                annotationTipClass: `arrow-down nv-event-annotation-layer-${config.sourceType}`,
+              });
               const records = (annotationData[e.name].records || [])
                 .map(r => {
                   const timeValue = new Date(moment.utc(r[e.timeColumn]));

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -295,7 +295,7 @@ export function wrapTooltip(chart, maxWidth) {
 
 export function tipFactory(layer) {
   return d3tip()
-    .attr('class', `d3-tip ${layer.annotationTipClass}`)
+    .attr('class', `d3-tip ${layer.annotationTipClass || ''}`)
     .direction('n')
     .offset([-5, 0])
     .html(d => {

--- a/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
+++ b/packages/superset-ui-legacy-preset-chart-nvd3/src/utils.js
@@ -295,7 +295,7 @@ export function wrapTooltip(chart, maxWidth) {
 
 export function tipFactory(layer) {
   return d3tip()
-    .attr('class', 'd3-tip')
+    .attr('class', `d3-tip ${layer.annotationTipClass}`)
     .direction('n')
     .offset([-5, 0])
     .html(d => {


### PR DESCRIPTION
🐛 Bug Fix

Airbnb user reported an issue that Interval type annotation overlapped with chart labels.
It seems the old UI look like this:
<img width="406" alt="Screen Shot 2019-10-17 at 3 29 03 PM (1)" src="https://user-images.githubusercontent.com/27990562/75296723-dec68900-57e2-11ea-96b4-c760715b24db.png">
This issue was reported pretty long time ago so I can't trace back since when we lost this container css. So I just added container class and some new css.

Before:
![Screen_Shot_2020-02-25_at_3_08_52_PM](https://user-images.githubusercontent.com/27990562/75295980-dbca9900-57e0-11ea-9e42-703b113b11e9.jpg)


After:
<img width="813" alt="Screen Shot 2020-02-25 at 4 20 15 PM" src="https://user-images.githubusercontent.com/27990562/75299770-ce1a1100-57ea-11ea-9824-26ec063a6e41.png">


@etr2460 @kristw @ktmud