### PR TITLE
fix(legacy-table): container height on tall headers

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-table/src/ReactDataTable.tsx
+++ b/packages/superset-ui-legacy-plugin-chart-table/src/ReactDataTable.tsx
@@ -185,15 +185,13 @@ export default function ReactDataTable(props: DataTableProps) {
     const dataTable = $root.find('table').DataTable(options);
 
     // adjust table height
-    const scrollHeadHeight = $root.find('.dataTables_scrollHead').height();
-    const paginationHeight = hasPagination ? $root.find('.dataTables_paginate').height() : 0;
+    const scrollHeadHeight = $root.find('.dataTables_scrollHead').height() || 0;
+    const paginationHeight = $root.find('.dataTables_paginate').height() || 0;
     const searchBarHeight =
-      hasPagination || includeSearch
-        ? $root
-            .find('.dataTables_length,.dataTables_filter')
-            .closest('.row')
-            .height()
-        : 0;
+      $root
+        .find('.dataTables_length,.dataTables_filter')
+        .closest('.row')
+        .height() || 0;
     const scrollBodyHeight = viewportHeight - scrollHeadHeight - paginationHeight - searchBarHeight;
     $root.find('.dataTables_scrollBody').css('max-height', scrollBodyHeight);
 

--- a/packages/superset-ui-legacy-plugin-chart-table/src/ReactDataTable.tsx
+++ b/packages/superset-ui-legacy-plugin-chart-table/src/ReactDataTable.tsx
@@ -185,9 +185,15 @@ export default function ReactDataTable(props: DataTableProps) {
     const dataTable = $root.find('table').DataTable(options);
 
     // adjust table height
-    const scrollHeadHeight = 34;
-    const paginationHeight = hasPagination ? 35 : 0;
-    const searchBarHeight = hasPagination || includeSearch ? 35 : 0;
+    const scrollHeadHeight = $root.find('.dataTables_scrollHead').height();
+    const paginationHeight = hasPagination ? $root.find('.dataTables_paginate').height() : 0;
+    const searchBarHeight =
+      hasPagination || includeSearch
+        ? $root
+            .find('.dataTables_length,.dataTables_filter')
+            .closest('.row')
+            .height()
+        : 0;
     const scrollBodyHeight = viewportHeight - scrollHeadHeight - paginationHeight - searchBarHeight;
     $root.find('.dataTables_scrollBody').css('max-height', scrollBodyHeight);
 
@@ -238,7 +244,7 @@ export default function ReactDataTable(props: DataTableProps) {
                   style={{
                     backgroundImage: keyIsMetric ? cellBar(key, val as number) : undefined,
                   }}
-                  title={keyIsMetric || percentMetricsSet.has(key) ? (val as string) : ''}
+                  title={keyIsMetric || percentMetricsSet.has(key) ? String(val) : ''}
                 >
                   {isHtml ? null : text}
                 </td>

--- a/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-table/birth_names.json
+++ b/packages/superset-ui-plugins-demo/storybook/stories/legacy-plugin-chart-table/birth_names.json
@@ -168,7 +168,7 @@
       "gender": "gender",
       "name": "name",
       "num": "num",
-      "state": "state",
+      "state": "state (this is a very very very long column)",
       "sum_boys": "sum_boys",
       "sum_girls": "sum_girls"
     },


### PR DESCRIPTION
[Previous change](https://github.com/apache-superset/superset-ui-plugins/pull/385) used fixed heights for those controls, as is in the new lunar data table chart implementation. It turns this breaks things. The table's scroll body overflows when header or search/pagination controls are too tall. 

This fix reverts back to parsing heights from the rendered DOM elements.

## Test Plan

After the fix, there should be some whitespace between table container and the root.

![image](https://user-images.githubusercontent.com/335541/76453632-6fc76380-6390-11ea-9122-4667341fae17.png)

🐛 Bug Fix

