### PR TITLE
fix(legacy-table): adjust sort icon position

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-table/src/Table.css
+++ b/packages/superset-ui-legacy-plugin-chart-table/src/Table.css
@@ -32,10 +32,11 @@
   margin-top: 0.5em;
 }
 
-.superset-legacy-chart-table thead th.sorting:after,
-table.table thead th.sorting_asc:after,
-table.table thead th.sorting_desc:after {
-  top: 0px;
+.superset-legacy-chart-table table.table thead th.sorting:after,
+.superset-legacy-chart-table table.table thead th.sorting_asc:after,
+.superset-legacy-chart-table table.table thead th.sorting_desc:after {
+  top: auto;
+  bottom: 6px;
 }
 .superset-legacy-chart-table td {
   white-space: pre-wrap;


### PR DESCRIPTION
This moves sort icons to the bottom of the table header.

Before:
![Snip20200311_42](https://user-images.githubusercontent.com/335541/76460449-419b5100-639b-11ea-8062-8aa97bf5d6e0.png)

After:
![Snip20200311_41](https://user-images.githubusercontent.com/335541/76460462-452ed800-639b-11ea-9634-1f7d1b3563b0.png)

🏆 Enhancements

