### PR TITLE
feat: more helpful error

### DIFF
--- a/packages/superset-ui-legacy-plugin-chart-horizon/src/HorizonChart.jsx
+++ b/packages/superset-ui-legacy-plugin-chart-horizon/src/HorizonChart.jsx
@@ -78,6 +78,8 @@ class HorizonChart extends React.PureComponent {
       yDomain = d3Extent(allValues, d => d.y);
     }
 
+    if (data.length <= 1) throw 'Please select a "Group by" option to enable multiple rows.';
+
     return (
       <div className={`superset-legacy-chart-horizon ${className}`} style={{ height }}>
         {data.map(row => (

--- a/packages/superset-ui-legacy-plugin-chart-horizon/src/HorizonChart.jsx
+++ b/packages/superset-ui-legacy-plugin-chart-horizon/src/HorizonChart.jsx
@@ -78,7 +78,8 @@ class HorizonChart extends React.PureComponent {
       yDomain = d3Extent(allValues, d => d.y);
     }
 
-    if (data.length <= 1) throw 'Please select a "Group by" option to enable multiple rows.';
+    if (data.length <= 1)
+      throw new Error('Please select a "Group by" option to enable multiple rows.');
 
     return (
       <div className={`superset-legacy-chart-horizon ${className}`} style={{ height }}>


### PR DESCRIPTION
🏆 Enhancements

There are probably a thousand of these we could do, but I found an easy yet cryptic error to replace with a more helpful one. Let me know if anyone has a preferred approach to these, or if I'm overlooking anything with this one.

Before:
<img width="1463" alt="Screen Shot 2020-03-24 at 9 18 19 AM" src="https://user-images.githubusercontent.com/812905/77451494-fa0cc000-6db1-11ea-8f89-407390b1fae0.png">

After:
<img width="1474" alt="Screen Shot 2020-03-24 at 9 18 55 AM" src="https://user-images.githubusercontent.com/812905/77451513-0002a100-6db2-11ea-976b-60efa6f21bd7.png">

